### PR TITLE
Fixing test collection in pytest

### DIFF
--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -112,10 +112,10 @@ def pytest_ignore_collect(path, config):
         only tests in test files with "repo_state_checks" in their path will be collected
     """
     if config.getoption("repo_health"):
-        if "repo_health" not in str(path):
+        if "/repo_health" not in str(path):
             return True
     else:
-        if "repo_health" in str(path):
+        if "/repo_health" in str(path):
             return True
     return False
 

--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -114,9 +114,6 @@ def pytest_ignore_collect(path, config):
     if config.getoption("repo_health"):
         if "/repo_health" not in str(path):
             return True
-    else:
-        if "/repo_health" in str(path):
-            return True
     return False
 
 def pytest_collection_modifyitems(session, config, items):


### PR DESCRIPTION
This would check to see if current part is in a some subdirectory called "repo_health*". And since we already changed test prefix to "check", the plugin should collect the right checks.