### PR TITLE
Add git and GitHub fixtures ARCHBOM-1310

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,30 @@ Unreleased
 
 *
 
-[0.1.0] - 2020-03-16
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1.1.0] - 2020-07-16
+~~~~~~~~~~~~~~~~~~~~
 
 Added
 _____
 
-* 
+* New fixtures that allow checks to easily fetch information about a git
+  repository: ``git_repo`` and ``git_origin_url``
+
+* New fixtures that allow checks to easily fetch information from the GitHub API
+  about the repository: ``github_client`` and ``github_repo``
+
+[1.0.0] - 2020-05-13
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* ``--repo-health-metadata`` option to collect metadata for each check and save it in a YAML file.
+
+* Added the current timestamp to the output (under ``TIMESTAMP``)
+
+
+[0.1.0] - 2020-04-13
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Initial release.

--- a/pytest_repo_health/__init__.py
+++ b/pytest_repo_health/__init__.py
@@ -5,7 +5,8 @@ and outputting report based on data gathered during checks.
 """
 
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
+
 
 def health_metadata(parent_path, output_keys):
     """
@@ -29,7 +30,6 @@ def health_metadata(parent_path, output_keys):
         key_path = tuple(parent_path + key_more)
         expanded_output_keys[key_path] = v
 
-
     def health_metadata_decorator(func):
         """Add metadata to function documenting the output keys it generates."""
         func.__dict__['pytest_repo_health'] = {
@@ -37,6 +37,7 @@ def health_metadata(parent_path, output_keys):
         }
         return func
     return health_metadata_decorator
+
 
 def add_key_to_metadata(output_key):
     """

--- a/pytest_repo_health/fixtures/__init__.py
+++ b/pytest_repo_health/fixtures/__init__.py
@@ -1,0 +1,3 @@
+"""
+Fixtures to simplify and improve the performance of repo health checks.
+"""

--- a/pytest_repo_health/fixtures/git.py
+++ b/pytest_repo_health/fixtures/git.py
@@ -21,7 +21,7 @@ def git_repo(repo_path):
 
 
 @pytest.fixture(scope="session")
-def git_origin_url(git_repo):
+def git_origin_url(git_repo):  # pylint: disable=redefined-outer-name
     """
     A fixture to fetch the URL of the online hosting for this repository.  Yields
     None if there is no origin defined for it, or if the target directory isn't

--- a/pytest_repo_health/fixtures/git.py
+++ b/pytest_repo_health/fixtures/git.py
@@ -18,3 +18,20 @@ def git_repo(repo_path):
     if path.is_dir():
         return Repo(repo_path)
     return None
+
+
+@pytest.fixture(scope="session")
+def git_origin_url(git_repo):
+    """
+    A fixture to fetch the URL of the online hosting for this repository.  Yields
+    None if there is no origin defined for it, or if the target directory isn't
+    even a git repository.
+    """
+    if git_repo is None:
+        return None
+    try:
+        origin = git_repo.remotes.origin
+    except ValueError:
+        # This local repository isn't linked to an online origin
+        return None
+    return origin.url

--- a/pytest_repo_health/fixtures/git.py
+++ b/pytest_repo_health/fixtures/git.py
@@ -1,0 +1,20 @@
+"""
+Fixtures for collecting data about git repositories.
+"""
+
+from pathlib import Path
+
+from git import Repo
+import pytest
+
+
+@pytest.fixture(scope="session")
+def git_repo(repo_path):
+    """
+    A fixture to fetch information about the git repository as checked out locally.
+    """
+    path = Path(repo_path) / '.git'
+    # If there isn't a .git directory, this isn't a git repository
+    if path.is_dir():
+        return Repo(repo_path)
+    return None

--- a/pytest_repo_health/fixtures/github.py
+++ b/pytest_repo_health/fixtures/github.py
@@ -25,7 +25,7 @@ def github_client():
 
 
 @pytest.fixture
-async def github_repo(git_origin_url, github_client, loop):
+async def github_repo(git_origin_url, github_client, loop):  # pylint: disable=redefined-outer-name, unused-argument
     """
     A fixture to fetch information from the GitHub API about the examined repository.
     Because github.py uses aiohttp, any checks using this fixture must be declared

--- a/pytest_repo_health/fixtures/github.py
+++ b/pytest_repo_health/fixtures/github.py
@@ -1,0 +1,43 @@
+"""
+Fixtures for getting information about a repository hosted on GitHub.
+"""
+import os
+import re
+
+import github
+import pytest
+
+URL_PATTERN = r"github.com[/:](?P<org_name>[^/]+)/(?P<repo_name>[^/\.]+)"
+
+
+@pytest.fixture(scope="session")
+def github_client():
+    """
+    A fixture to initialize a GitHub API client, using the personal access token
+    obtained from the GITHUB_TOKEN environment variable.
+    """
+    try:
+        token = os.environ["GITHUB_TOKEN"]
+    except KeyError:
+        raise Exception("To use any of the GitHub fixtures, you must set the GITHUB_TOKEN environment variable "
+                        "to contain a GitHub personal access token.")
+    return github.GitHub(token)
+
+
+@pytest.fixture
+async def github_repo(git_origin_url, github_client, loop):
+    """
+    A fixture to fetch information from the GitHub API about the examined repository.
+    Because github.py uses aiohttp, any checks using this fixture must be declared
+    via ``async def``.
+    """
+    if git_origin_url is None:
+        # There isn't an origin for this repository or directory
+        return None
+    match = re.search(URL_PATTERN, git_origin_url)
+    if match is None:
+        # The origin isn't hosted on GitHub (might be GitLab, Bitbucket, etc.)
+        return None
+    org_name = match.group("org_name")
+    repo_name = match.group("repo_name")
+    return await github_client.fetch_repository(org_name, repo_name)

--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -8,7 +8,8 @@ import datetime
 import pytest
 import yaml
 
-from .fixtures.git import git_repo  # pylint: disable=unused-import
+from .fixtures.git import git_origin_url, git_repo  # pylint: disable=unused-import
+from .fixtures.github import github_client, github_repo  # pylint: disable=unused-import
 
 
 session_data_holder_dict = defaultdict(dict)

--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -8,7 +8,7 @@ import datetime
 import pytest
 import yaml
 
-from .fixtures.git import git_repo
+from .fixtures.git import git_repo  # pylint: disable=unused-import
 
 
 session_data_holder_dict = defaultdict(dict)

--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -8,16 +8,17 @@ import datetime
 import pytest
 import yaml
 
-from fixtures.git import git_repo
-from fixtures.github import github_repo
+from .fixtures.git import git_repo
 
 
 session_data_holder_dict = defaultdict(dict)
 session_data_holder_dict["TIMESTAMP"] = datetime.datetime.now().date()
 
+
 @pytest.fixture(scope="session")
 def all_results():
     return session_data_holder_dict
+
 
 def pytest_configure(config):
     """
@@ -30,13 +31,13 @@ def pytest_configure(config):
         file_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
         config.args.append(file_dir)
 
-        # add repo path so a repo can design their own checks inside a repo_state_checks dir
+        # add repo path so a repo can design their own checks inside a repo_health dir
         repo_path = config.getoption("repo_path")  # pylint: disable=redefined-outer-name
         if repo_path is None:
             repo_path = os.getcwd()
         config.args.append(os.path.abspath(repo_path))
 
-        # in case repo_health checks are in seperate repo
+        # in case repo_health checks are in separate repo
         repo_health_path = config.getoption("repo_health_path")
         if repo_health_path is not None:
             config.args.append(os.path.abspath(repo_health_path))
@@ -95,7 +96,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def repo_path(request):
     """
     pytest fixture to be used to get path to repo being tested
@@ -105,6 +106,7 @@ def repo_path(request):
         path = os.getcwd()
     path = os.path.abspath(path)
     return path
+
 
 @pytest.fixture
 def repo_health(request):
@@ -117,16 +119,18 @@ def repo_health(request):
     """
     return request.config.option.repo_health
 
+
 def pytest_ignore_collect(path, config):
     """
     pytest hook that determines if pytest looks at specific file to collect tests
     if repo_health is set to true:
-        only tests in test files with "repo_state_checks" in their path will be collected
+        only tests in test files with "repo_health" in their path will be collected
     """
     if config.getoption("repo_health"):
         if "/repo_health" not in str(path):
             return True
     return False
+
 
 # Unused argument "session", but pylint complains if it is renamed "_session"
 # pylint: disable=unused-argument

--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -6,8 +6,10 @@ from collections import defaultdict
 import datetime
 
 import pytest
-
 import yaml
+
+from fixtures.git import git_repo
+from fixtures.github import github_repo
 
 
 session_data_holder_dict = defaultdict(dict)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,4 +4,5 @@
 github.py                 # GitHub API bindings for the GitHub repository data fixtures
 GitPython                 # Python wrapper for the git binary, for the git repository data fixtures
 pytest                    # Framework used to find and execute each "opynion"
+pytest-aiohttp            # Async test support, needed to use the github.py package for the GitHub API fixtures
 pyyaml                    # For saving the collected data in a YAML file

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,7 @@
 # Core requirements for using this application
 -c constraints.txt
 
+github.py                 # GitHub API bindings for the GitHub repository data fixtures
+GitPython                 # Python wrapper for the git binary, for the git repository data fixtures
 pytest                    # Framework used to find and execute each "opynion"
-pyyaml
+pyyaml                    # For saving the collected data in a YAML file

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.6.2            # via github.py
+aiohttp==3.6.2            # via github.py, pytest-aiohttp
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
@@ -21,7 +21,8 @@ pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pyparsing==2.4.7          # via packaging
-pytest==5.4.3             # via -r requirements/base.in
+pytest-aiohttp==0.3.0     # via -r requirements/base.in
+pytest==5.4.3             # via -r requirements/base.in, pytest-aiohttp
 pyyaml==5.3.1             # via -r requirements/base.in
 six==1.15.0               # via packaging, pathlib2
 smmap==3.0.4              # via gitdb

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,18 @@
 #
 #    make upgrade
 #
-attrs==19.3.0             # via pytest
+aiohttp==3.6.2            # via github.py
+async-timeout==3.0.1      # via aiohttp
+attrs==19.3.0             # via aiohttp, pytest
+chardet==3.0.4            # via aiohttp
+gitdb==4.0.5              # via gitpython
+github.py==0.5.0          # via -r requirements/base.in
+gitpython==3.1.7          # via -r requirements/base.in
+idna-ssl==1.1.0           # via aiohttp
+idna==2.10                # via idna-ssl, yarl
 importlib-metadata==1.7.0  # via pluggy, pytest
 more-itertools==8.4.0     # via pytest
+multidict==4.7.6          # via aiohttp, yarl
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
@@ -15,5 +24,8 @@ pyparsing==2.4.7          # via packaging
 pytest==5.4.3             # via -r requirements/base.in
 pyyaml==5.3.1             # via -r requirements/base.in
 six==1.15.0               # via packaging, pathlib2
+smmap==3.0.4              # via gitdb
+typing-extensions==3.7.4.2  # via aiohttp
 wcwidth==0.2.5            # via pytest
+yarl==1.4.2               # via aiohttp
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,13 @@
 #
 #    make upgrade
 #
+aiohttp==3.6.2            # via -r requirements/quality.txt, github.py
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/quality.txt, pytest
+async-timeout==3.0.1      # via -r requirements/quality.txt, aiohttp
+attrs==19.3.0             # via -r requirements/quality.txt, aiohttp, pytest
 certifi==2020.6.20        # via -r requirements/travis.txt, requests
-chardet==3.0.4            # via -r requirements/travis.txt, requests
+chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
 codecov==2.1.7            # via -r requirements/travis.txt
@@ -17,7 +19,11 @@ diff-cover==3.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 edx-lint==1.5.0           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-idna==2.10                # via -r requirements/travis.txt, requests
+gitdb==4.0.5              # via -r requirements/quality.txt, gitpython
+github.py==0.5.0          # via -r requirements/quality.txt
+gitpython==3.1.7          # via -r requirements/quality.txt
+idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
+idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 inflect==3.0.2            # via jinja2-pluralize
@@ -28,6 +34,7 @@ lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 more-itertools==8.4.0     # via -r requirements/quality.txt, pytest
+multidict==4.7.6          # via -r requirements/quality.txt, aiohttp, yarl
 packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
 pip-tools==5.2.1          # via -r requirements/pip-tools.txt
@@ -46,15 +53,18 @@ pytest==5.4.3             # via -r requirements/quality.txt, pytest-cov
 pyyaml==5.3.1             # via -r requirements/quality.txt
 requests==2.24.0          # via -r requirements/travis.txt, codecov
 six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, diff-cover, edx-lint, packaging, pathlib2, pip-tools, tox, virtualenv
+smmap==3.0.4              # via -r requirements/quality.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 toml==0.10.1              # via -r requirements/travis.txt, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
 tox==3.16.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
+typing-extensions==3.7.4.2  # via -r requirements/quality.txt, aiohttp
 urllib3==1.25.9           # via -r requirements/travis.txt, requests
 virtualenv==20.0.26       # via -r requirements/travis.txt, tox
 wcwidth==0.2.5            # via -r requirements/quality.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
+yarl==1.4.2               # via -r requirements/quality.txt, aiohttp
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.6.2            # via -r requirements/quality.txt, github.py
+aiohttp==3.6.2            # via -r requirements/quality.txt, github.py, pytest-aiohttp
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
 async-timeout==3.0.1      # via -r requirements/quality.txt, aiohttp
@@ -48,8 +48,9 @@ pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
+pytest-aiohttp==0.3.0     # via -r requirements/quality.txt
 pytest-cov==2.10.0        # via -r requirements/quality.txt
-pytest==5.4.3             # via -r requirements/quality.txt, pytest-cov
+pytest==5.4.3             # via -r requirements/quality.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/quality.txt
 requests==2.24.0          # via -r requirements/travis.txt, codecov
 six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, diff-cover, edx-lint, packaging, pathlib2, pip-tools, tox, virtualenv
@@ -57,11 +58,11 @@ smmap==3.0.4              # via -r requirements/quality.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 toml==0.10.1              # via -r requirements/travis.txt, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.16.1               # via -r requirements/travis.txt, tox-battery
+tox==3.17.0               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 typing-extensions==3.7.4.2  # via -r requirements/quality.txt, aiohttp
 urllib3==1.25.9           # via -r requirements/travis.txt, requests
-virtualenv==20.0.26       # via -r requirements/travis.txt, tox
+virtualenv==20.0.27       # via -r requirements/travis.txt, tox
 wcwidth==0.2.5            # via -r requirements/quality.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
 yarl==1.4.2               # via -r requirements/quality.txt, aiohttp

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,22 +4,29 @@
 #
 #    make upgrade
 #
+aiohttp==3.6.2            # via -r requirements/test.txt, github.py
 alabaster==0.7.12         # via sphinx
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
+attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
 babel==2.8.0              # via sphinx
 bleach==3.1.5             # via readme-renderer
 certifi==2020.6.20        # via requests
-chardet==3.0.4            # via doc8, requests
+chardet==3.0.4            # via -r requirements/test.txt, aiohttp, doc8, requests
 coverage==5.2             # via -r requirements/test.txt, pytest-cov
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-idna==2.10                # via requests
+gitdb==4.0.5              # via -r requirements/test.txt, gitpython
+github.py==0.5.0          # via -r requirements/test.txt
+gitpython==3.1.7          # via -r requirements/test.txt
+idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
+idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+multidict==4.7.6          # via -r requirements/test.txt, aiohttp, yarl
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via stevedore
@@ -35,6 +42,7 @@ readme-renderer==26.0     # via -r requirements/doc.in
 requests==2.24.0          # via sphinx
 restructuredtext-lint==1.3.1  # via doc8
 six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, packaging, pathlib2, readme-renderer, stevedore
+smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
 sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
@@ -44,9 +52,11 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 stevedore==1.32.0         # via doc8
+typing-extensions==3.7.4.2  # via -r requirements/test.txt, aiohttp
 urllib3==1.25.9           # via requests
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
+yarl==1.4.2               # via -r requirements/test.txt, aiohttp
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.6.2            # via -r requirements/test.txt, github.py
+aiohttp==3.6.2            # via -r requirements/test.txt, github.py, pytest-aiohttp
 alabaster==0.7.12         # via sphinx
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
@@ -34,8 +34,9 @@ pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
+pytest-aiohttp==0.3.0     # via -r requirements/test.txt
 pytest-cov==2.10.0        # via -r requirements/test.txt
-pytest==5.4.3             # via -r requirements/test.txt, pytest-cov
+pytest==5.4.3             # via -r requirements/test.txt, pytest-aiohttp, pytest-cov
 pytz==2020.1              # via babel
 pyyaml==5.3.1             # via -r requirements/test.txt
 readme-renderer==26.0     # via -r requirements/doc.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,17 +4,26 @@
 #
 #    make upgrade
 #
+aiohttp==3.6.2            # via -r requirements/test.txt, github.py
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
+attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
+chardet==3.0.4            # via -r requirements/test.txt, aiohttp
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coverage==5.2             # via -r requirements/test.txt, pytest-cov
 edx-lint==1.5.0           # via -r requirements/quality.in
+gitdb==4.0.5              # via -r requirements/test.txt, gitpython
+github.py==0.5.0          # via -r requirements/test.txt
+gitpython==3.1.7          # via -r requirements/test.txt
+idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
+idna==2.10                # via -r requirements/test.txt, idna-ssl, yarl
 importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+multidict==4.7.6          # via -r requirements/test.txt, aiohttp, yarl
 packaging==20.4           # via -r requirements/test.txt, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
@@ -30,8 +39,11 @@ pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov
 pyyaml==5.3.1             # via -r requirements/test.txt
 six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, packaging, pathlib2
+smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via pydocstyle
 typed-ast==1.4.1          # via astroid
+typing-extensions==3.7.4.2  # via -r requirements/test.txt, aiohttp
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via astroid
+yarl==1.4.2               # via -r requirements/test.txt, aiohttp
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.6.2            # via -r requirements/test.txt, github.py
+aiohttp==3.6.2            # via -r requirements/test.txt, github.py, pytest-aiohttp
 astroid==2.3.3            # via pylint, pylint-celery
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
@@ -35,8 +35,9 @@ pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
+pytest-aiohttp==0.3.0     # via -r requirements/test.txt
 pytest-cov==2.10.0        # via -r requirements/test.txt
-pytest==5.4.3             # via -r requirements/test.txt, pytest-cov
+pytest==5.4.3             # via -r requirements/test.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/test.txt
 six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, packaging, pathlib2
 smmap==3.0.4              # via -r requirements/test.txt, gitdb

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,10 +4,19 @@
 #
 #    make upgrade
 #
-attrs==19.3.0             # via -r requirements/base.txt, pytest
+aiohttp==3.6.2            # via -r requirements/base.txt, github.py
+async-timeout==3.0.1      # via -r requirements/base.txt, aiohttp
+attrs==19.3.0             # via -r requirements/base.txt, aiohttp, pytest
+chardet==3.0.4            # via -r requirements/base.txt, aiohttp
 coverage==5.2             # via pytest-cov
+gitdb==4.0.5              # via -r requirements/base.txt, gitpython
+github.py==0.5.0          # via -r requirements/base.txt
+gitpython==3.1.7          # via -r requirements/base.txt
+idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
+idna==2.10                # via -r requirements/base.txt, idna-ssl, yarl
 importlib-metadata==1.7.0  # via -r requirements/base.txt, pluggy, pytest
 more-itertools==8.4.0     # via -r requirements/base.txt, pytest
+multidict==4.7.6          # via -r requirements/base.txt, aiohttp, yarl
 packaging==20.4           # via -r requirements/base.txt, pytest
 pathlib2==2.3.5           # via -r requirements/base.txt, pytest
 pluggy==0.13.1            # via -r requirements/base.txt, pytest
@@ -17,5 +26,8 @@ pytest-cov==2.10.0        # via -r requirements/test.in
 pytest==5.4.3             # via -r requirements/base.txt, pytest-cov
 pyyaml==5.3.1             # via -r requirements/base.txt
 six==1.15.0               # via -r requirements/base.txt, packaging, pathlib2
+smmap==3.0.4              # via -r requirements/base.txt, gitdb
+typing-extensions==3.7.4.2  # via -r requirements/base.txt, aiohttp
 wcwidth==0.2.5            # via -r requirements/base.txt, pytest
+yarl==1.4.2               # via -r requirements/base.txt, aiohttp
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.6.2            # via -r requirements/base.txt, github.py
+aiohttp==3.6.2            # via -r requirements/base.txt, github.py, pytest-aiohttp
 async-timeout==3.0.1      # via -r requirements/base.txt, aiohttp
 attrs==19.3.0             # via -r requirements/base.txt, aiohttp, pytest
 chardet==3.0.4            # via -r requirements/base.txt, aiohttp
@@ -22,8 +22,9 @@ pathlib2==2.3.5           # via -r requirements/base.txt, pytest
 pluggy==0.13.1            # via -r requirements/base.txt, pytest
 py==1.9.0                 # via -r requirements/base.txt, pytest
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
+pytest-aiohttp==0.3.0     # via -r requirements/base.txt
 pytest-cov==2.10.0        # via -r requirements/test.in
-pytest==5.4.3             # via -r requirements/base.txt, pytest-cov
+pytest==5.4.3             # via -r requirements/base.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/base.txt
 six==1.15.0               # via -r requirements/base.txt, packaging, pathlib2
 smmap==3.0.4              # via -r requirements/base.txt, gitdb

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -22,7 +22,7 @@ requests==2.24.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.16.1               # via -r requirements/travis.in, tox-battery
+tox==3.17.0               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
-virtualenv==20.0.26       # via tox
+virtualenv==20.0.27       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 import re
 import codecs
-from setuptools import setup
+from setuptools import find_packages, setup
 
 def get_version(*file_paths):
     """
@@ -60,7 +60,7 @@ setup(
     url='https://github.com/edX/pytest-repo-health',
     description='A pytest plugin to report on repository standards conformance',
     long_description=read('README.rst'),
-    py_modules=['pytest_repo_health.plugin'],
+    packages=find_packages(exclude=["tests"]),
     python_requires=">=3.5",
     install_requires=load_requirements('requirements/base.in'),
     zip_safe=False,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 PYTEST_INI = """
 [pytest]
-addopts = -vv --repo-health --repo-health-path {checks_path} --repo-path {repo_path}
+addopts = --repo-health --repo-health-path {checks_path} --repo-path {repo_path}
 """
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,33 @@
+"""
+Tests of the pytest-repo-health plugin itself (including the fixtures it provides).
+"""
+from pathlib import Path
+
+PYTEST_INI = """
+[pytest]
+addopts = -vv --repo-health --repo-health-path {checks_path} --repo-path {repo_path}
+"""
+
+
+def run_checks(testdir, repo_path=None, **kwargs):
+    """
+    Put the check file content for each provided kwarg key into check files under the
+    specified test directory, and then run them.  Runs the checks against the root of
+    this repository by default, specify repo_path to run against a different directory.
+
+    Returns the pytester RunResult so the results can be examined.
+    """
+    # Must put checks in a "repo_health" subdirectory to be collected
+    testdir.mkpydir("repo_health")
+    checks_path = Path(str(testdir.tmpdir)) / "repo_health"
+    # The testdir convenience methods for file creation only work in the base directory
+    for path, content in kwargs.items():
+        file_path = checks_path / "check_{}.py".format(path)
+        with open(str(file_path), "w") as f:
+            f.write(content)
+    if repo_path is None:
+        repo_path = Path(__file__).parent / ".."
+    # Tell pytest where to find the checks and to run them on the real repository root
+    testdir.makefile(".ini", pytest=PYTEST_INI.format(checks_path=str(checks_path),
+                                                      repo_path=str(repo_path)))
+    return testdir.runpytest()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,5 @@
 """
 conftest used to run tests on pytest-repo-health plugin
 """
-import pytest
 
 pytest_plugins = ['pytester']
-
-
-FILE = """
-def check_test_collection(all_results):
-    all_results["Yes"] = "NOOOO"
-"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ conftest used to run tests on pytest-repo-health plugin
 """
 import pytest
 
-pytest_plugins = 'pytester'
+pytest_plugins = ['pytester']
 
 
 FILE = """

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,31 @@
+"""
+Tests to make sure the pytest-repo-health plugin fixtures work correctly.
+"""
+
+from . import run_checks
+
+GIT_REPO = """
+def check_git_repo(git_repo):
+    assert git_repo.working_tree_dir
+"""
+
+NOT_GIT_REPO = """
+def check_not_git_repo(all_results, git_repo):
+    assert git_repo is None
+"""
+
+
+def test_git_repo(testdir):
+    """
+    Verify that the git_repo fixture initializes correctly when running against a git checkout
+    """
+    result = run_checks(testdir, git_repo=GIT_REPO)
+    result.assert_outcomes(passed=1)
+
+
+def test_not_git_repo(testdir):
+    """
+    Verify that the git_repo fixture gracefully yields None when not running against a git checkout
+    """
+    result = run_checks(testdir, repo_path=str(testdir.tmpdir), not_git_repo=NOT_GIT_REPO)
+    result.assert_outcomes(passed=1)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -2,30 +2,61 @@
 Tests to make sure the pytest-repo-health plugin fixtures work correctly.
 """
 
+import os
+
+import pytest
+
 from . import run_checks
 
 GIT_REPO = """
 def check_git_repo(git_repo):
     assert git_repo.working_tree_dir
+
+def check_git_origin_url(git_origin_url):
+    assert "/pytest-repo-health" in git_origin_url
 """
 
 NOT_GIT_REPO = """
 def check_not_git_repo(all_results, git_repo):
     assert git_repo is None
+
+def check_git_origin_url(git_origin_url):
+    assert git_origin_url is None
+"""
+
+GITHUB = """
+import os
+import pytest
+
+def check_github_client(github_client):
+    assert github_client is not None
+
+async def check_github_repo(github_repo):
+    assert github_repo.created_at
 """
 
 
 def test_git_repo(testdir):
     """
-    Verify that the git_repo fixture initializes correctly when running against a git checkout
+    Verify that the git fixtures initialize correctly when running against a git checkout
     """
     result = run_checks(testdir, git_repo=GIT_REPO)
-    result.assert_outcomes(passed=1)
+    result.assert_outcomes(passed=2)
 
 
 def test_not_git_repo(testdir):
     """
-    Verify that the git_repo fixture gracefully yields None when not running against a git checkout
+    Verify that the git fixtures gracefully yield None when not running against a git checkout
     """
     result = run_checks(testdir, repo_path=str(testdir.tmpdir), not_git_repo=NOT_GIT_REPO)
-    result.assert_outcomes(passed=1)
+    result.assert_outcomes(passed=2)
+
+
+@pytest.mark.skipif("GITHUB_TOKEN" not in os.environ,
+                    reason="The GITHUB_TOKEN environment must be set to use the GitHub API fixtures")
+def test_github(testdir):
+    """
+    Verify that the GitHub fixtures initialize correctly.
+    """
+    result = run_checks(testdir, github=GITHUB)
+    result.assert_outcomes(passed=2)

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ max-line-length = 120
 testpaths = pytest_repo_health tests
 
 [testenv]
+passenv =
+    GITHUB_TOKEN
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
Added fixtures to fetch data from both the local git repository and the GitHub API:

* Added a `git_repo` fixture to get information about the checked out repository
* Added a `git_origin_url` fixture to get the configured SSH or HTTPS URL for the repository's origin
* Added a `github_client` fixture to initialize a GitHub API client using a personal access token from the `GITHUB_TOKEN` environment variable
* Added a `github_repo` fixture to return a github.py `Repository` object for the repo being examined.  This fixture has function scope rather than session like the other new ones, since the `loop` fixture needed to support github.py's async network calls is also function-scoped.
* Added the packages needed to work with git and the GitHub API
* Refactored the test suite to correctly run sample checks that exercise fixtures
* Added tests for the new fixtures (the ones that actually talk to the GitHub API are skipped if the token environment variable isn't set)
* Fixed some minor docstring errors in the plugin module

I considered making the new dependencies optional, but would make the fixtures code a bit messier because they all have to be imported in the plugin module, even if they aren't used for a particular set of checks.