### PR TITLE
Gracefully handle errors fetching GitHub data ARCHBOM-1310

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Unreleased
 
 *
 
+[1.1.1] - 2020-07-21
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+_____
+
+* Gracefully handle errors in fetching data from GitHub
+
 [1.1.0] - 2020-07-16
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/pytest_repo_health/__init__.py
+++ b/pytest_repo_health/__init__.py
@@ -5,7 +5,7 @@ and outputting report based on data gathered during checks.
 """
 
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 
 def health_metadata(parent_path, output_keys):


### PR DESCRIPTION
We're hitting GitHub internal errors trying to fetch data from the edx-blog repository.  I've submitted a ticket to GitHub, but we should handle such cases gracefully without causing the entire health check to fail.