### PR TITLE
Adding tests for decorators

### DIFF
--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -7,6 +7,7 @@ import datetime
 
 import pytest
 import yaml
+import pdb
 
 from .fixtures.git import git_origin_url, git_repo  # pylint: disable=unused-import
 from .fixtures.github import github_client, github_repo  # pylint: disable=unused-import
@@ -139,17 +140,30 @@ def pytest_collection_modifyitems(session, config, items):
     """
     pytest hook, post-collection: Read output key metadata from checks
     and dump to metadata.yaml in current working directory.
+
+    Arguments:
+        - session:  the pytest session object
+        - config: pytest config object
+        - items: list of item objects: one item: a basic test invocation item
     """
     if config.getoption("repo_health") and config.getoption("repo_health_metadata"):
         checks_metadata = {}
         for item in items:
-            item_meta = item.function.__dict__.get('pytest_repo_health')
+            # check to see item has any metadata related to pytest_repo_health
+            item_meta = item.function.__dict__.get('pytest_repo_health', None)
             if item_meta is not None:
+                # store all data based for one module in its dict
                 module_name = item.parent.name
                 if item.parent.name not in checks_metadata.keys():
-                    checks_metadata[module_name] = {'module_doc_string':item.parent.module.__doc__.strip()}
+                    checks_metadata[module_name] = {}
+                    # add modules docstring to data if present
+                    if item.parent.module.__doc__ is not None:
+                        checks_metadata[module_name]['module_doc_string'] = item.parent.module.__doc__.strip()
+                # Add function metadata to module dict
                 checks_metadata[module_name][item.name] = item_meta
-                checks_metadata[module_name][item.name]["doc_string"] = item.function.__doc__.strip()
+                # add doc string if function also has doc string
+                if item.function.__doc__ is not None:
+                    checks_metadata[module_name][item.name]["doc_string"] = item.function.__doc__.strip()
         with open("metadata.yaml", "w") as write_file:
             yaml.dump(checks_metadata, write_file, indent=4)
 

--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -7,7 +7,6 @@ import datetime
 
 import pytest
 import yaml
-import pdb
 
 from .fixtures.git import git_origin_url, git_repo  # pylint: disable=unused-import
 from .fixtures.github import github_client, github_repo  # pylint: disable=unused-import

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 PYTEST_INI = """
 [pytest]
-addopts = --repo-health --repo-health-path {checks_path} --repo-path {repo_path}
+addopts = --repo-health --repo-health-path {checks_path} --repo-path {repo_path} --repo-health-metadata
 """
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,0 @@
-"""
-conftest used to run tests on pytest-repo-health plugin
-"""
-
-pytest_plugins = ['pytester']

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -4,7 +4,6 @@ Tests to make sure health_metadata and add_key_to_metadata decorators function c
 
 from . import run_checks
 import yaml
-import pdb
 
 
 TEST_HEALTH_METADATA = """

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,70 @@
+"""
+Tests to make sure health_metadata and add_key_to_metadata decorators function correctly
+"""
+
+from . import run_checks
+import yaml
+import pdb
+
+
+TEST_HEALTH_METADATA = """
+from pytest_repo_health import health_metadata
+module_dict_key = "parent"
+@health_metadata([module_dict_key], {"key1": "doc1", "key2": "doc2"})
+def check_decorator(all_results):
+    all_results[module_dict_key]["key1"] = "NOOOO"
+    all_results[module_dict_key]["key2"] = "FFFFFAAALLSE"
+"""
+
+
+def test_health_metadata(testdir):
+    """
+    Test to make sure health_metadata correctly adds docs to func's __dict__.
+
+    and make sure the plugin outputs it correctly in yaml
+    """
+    result = run_checks(testdir, test_health_metadata=TEST_HEALTH_METADATA)
+    result.assert_outcomes(passed=1)
+    metadata_yaml_path = testdir.tmpdir / 'metadata.yaml'
+    assert (metadata_yaml_path).exists()
+    with open(metadata_yaml_path) as y_f:
+        content = yaml.load(y_f)
+        # name based on kwrg input to run_checks funtion
+        assert "check_test_health_metadata.py" in content.keys()
+        assert "check_decorator" in content["check_test_health_metadata.py"]
+        assert "output_keys" in content["check_test_health_metadata.py"]["check_decorator"]
+        assert ('parent', 'key1') in content["check_test_health_metadata.py"]["check_decorator"]["output_keys"]
+        assert ('parent', 'key2') in content["check_test_health_metadata.py"]["check_decorator"]["output_keys"]
+        assert "doc1" == content["check_test_health_metadata.py"]["check_decorator"]["output_keys"][('parent', 'key1')]
+        assert "doc2" == content["check_test_health_metadata.py"]["check_decorator"]["output_keys"][('parent', 'key2')]
+
+
+TEST_ADD_KEY_TO_METADATA = """
+from pytest_repo_health import add_key_to_metadata
+module_dict_key = "parent"
+@add_key_to_metadata((module_dict_key, "key1"))
+def check_decorator(all_results):
+    "doc1"
+    all_results[module_dict_key]["key1"] = "NOOOO"
+"""
+
+
+def test_add_key_to_metadata(testdir):
+    """
+    Test to make sure add_key_to_metadata correctly adds docs to func's __dict__.
+
+    and make sure the plugin outputs it correctly in yaml
+    """
+    result = run_checks(testdir, test_add_key_to_metadata=TEST_ADD_KEY_TO_METADATA)
+    result.assert_outcomes(passed=1)
+    metadata_yaml_path = testdir.tmpdir / 'metadata.yaml'
+    assert (metadata_yaml_path).exists()
+    with open(metadata_yaml_path) as y_f:
+        content = yaml.load(y_f)
+        # name based on kwrg input to run_checks funtion
+        assert "check_test_add_key_to_metadata.py" in content.keys()
+        assert "check_decorator" in content["check_test_add_key_to_metadata.py"]
+        assert "output_keys" in content["check_test_add_key_to_metadata.py"]["check_decorator"]
+        assert ('parent', 'key1') in content["check_test_add_key_to_metadata.py"]["check_decorator"]["output_keys"]
+        assert "doc1" == content["check_test_add_key_to_metadata.py"]["check_decorator"]["output_keys"][('parent', 'key1')]
+

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -60,7 +60,7 @@ def test_add_key_to_metadata(testdir):
     metadata_yaml_path = testdir.tmpdir / 'metadata.yaml'
     assert (metadata_yaml_path).exists()
     # converting metadata_yaml_path to str cause pathlib doesn't work will with open in python 3.5
-    with open(metadata_yaml_path) as y_f:
+    with open(str(metadata_yaml_path)) as y_f:
         content = yaml.load(y_f)
         # name based on kwrg input to run_checks funtion
         assert "check_test_add_key_to_metadata.py" in content.keys()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -26,7 +26,8 @@ def test_health_metadata(testdir):
     result.assert_outcomes(passed=1)
     metadata_yaml_path = testdir.tmpdir / 'metadata.yaml'
     assert (metadata_yaml_path).exists()
-    with open(metadata_yaml_path) as y_f:
+    # converting metadata_yaml_path to str cause pathlib doesn't work will with open in python 3.5
+    with open(str(metadata_yaml_path)) as y_f:
         content = yaml.load(y_f)
         # name based on kwrg input to run_checks funtion
         assert "check_test_health_metadata.py" in content.keys()
@@ -58,6 +59,7 @@ def test_add_key_to_metadata(testdir):
     result.assert_outcomes(passed=1)
     metadata_yaml_path = testdir.tmpdir / 'metadata.yaml'
     assert (metadata_yaml_path).exists()
+    # converting metadata_yaml_path to str cause pathlib doesn't work will with open in python 3.5
     with open(metadata_yaml_path) as y_f:
         content = yaml.load(y_f)
         # name based on kwrg input to run_checks funtion

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ max-line-length = 120
 
 [pytest]
 testpaths = pytest_repo_health tests
+addopts = -p pytester
 
 [testenv]
 passenv =


### PR DESCRIPTION
Adds tests to make sure the decorators don't regress and changes how the plugin "pytester" is added to work with https://docs.pytest.org/en/stable/deprecations.html#pytest-plugins-in-non-top-level-conftest-files. This deprecation was making testing locally harder.