### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ sudo: false
 language: python
 matrix:
   include:
-  - python: 3.5
-    env: TOX_ENV=py35
+  - python: 3.6
+    env: TOX_ENV=py36
+  - python: 3.7
+    env: TOX_ENV=py37
   - python: 3.8
     env: TOX_ENV=py38
   - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     env: TOX_ENV=py37
   - python: 3.8
     env: TOX_ENV=py38
-  - python: 3.5
+  - python: 3.6
     env: TOX_ENV=quality
 install:
 - pip install -r requirements/travis.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-*
+Removed
+_______
+
+* Support for Python 3.5.  Versions 3.5.3 and above will likely still work for now, but they are no longer being tested; this lets us upgrade some dependencies and avoid confusion when aiohttp fails to install under 3.5.2 and below.  Python 3.5 reaches EOL in 1.5 months anyway.
 
 [1.1.1] - 2020-07-21
 ~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 # pylint: disable= missing-module-docstring
 
+import codecs
 import os
 import re
-import codecs
+import sys
 from setuptools import find_packages, setup
+
 
 def get_version(*file_paths):
     """
@@ -22,6 +24,7 @@ def read(fname):
     file_path = os.path.join(os.path.dirname(__file__), fname)
     return codecs.open(file_path, encoding='utf-8').read()
 
+
 def load_requirements(*requirements_paths):
     """
     Load all requirements from the specified requirements files.
@@ -35,7 +38,6 @@ def load_requirements(*requirements_paths):
             if is_requirement(line.strip())
         )
     return list(requirements)
-
 
 
 def is_requirement(line):
@@ -52,6 +54,12 @@ README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 CHANGELOG = open(os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst')).read()
 VERSION = get_version('pytest_repo_health', '__init__.py')
 
+if sys.argv[-1] == 'tag':
+    print("Tagging the version on github:")
+    os.system("git tag -a %s -m '%s'" % (VERSION, VERSION))
+    os.system("git push --tags")
+    sys.exit()
+
 setup(
     name='pytest-repo-health',
     version=VERSION,
@@ -61,7 +69,7 @@ setup(
     description='A pytest plugin to report on repository standards conformance',
     long_description=read('README.rst'),
     packages=find_packages(exclude=["tests"]),
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=load_requirements('requirements/base.in'),
     zip_safe=False,
     keywords='pytest edx',
@@ -73,7 +81,9 @@ setup(
         'Natural Language :: English',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py35,py38,quality
+envlist = py36,py37,py38,quality
 
 [doc8]
 max-line-length = 120


### PR DESCRIPTION
Removing 3.5 support since we aren't using it, it reaches EOL in about 45 days, and it's causing some confusion between different 3.5.x versions on various systems (aiohttp has dropped support for < 3.5.3).  Also added the standard `setup.py` code to simplify tagging new releases.

Not releasing a new version yet, since these changes don't add anything we need yet; just preparing this for the next release that actually includes new features.