### PR TITLE
Upgrade github.py and fix .github repo handling ARCHBOM-1383

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,19 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.0.0] - 2020-07-21
+~~~~~~~~~~~~~~~~~~~~
+
 Removed
 _______
 
-* Support for Python 3.5.  Versions 3.5.3 and above will likely still work for now, but they are no longer being tested; this lets us upgrade some dependencies and avoid confusion when aiohttp fails to install under 3.5.2 and below.  Python 3.5 reaches EOL in 1.5 months anyway.
+* Support for Python 3.5.  Versions 3.5.3 and above will likely still work for now, but they are no longer being tested; this lets us upgrade some dependencies and avoid confusion when aiohttp fails to install under 3.5.2 and below.  Python 3.5 reaches EOL in 1 month anyway.
+
+Fixed
+_____
+
+* Recent versions of github.py installed from source control are now supported (and recommended if you want to inspect a repository's code of conduct, as 0.5.0 has a bug that throws an exception when attempting this).
+* Checks can now be run on a ``.github`` repository (the regular expression used to parse out the organization and repository names didn't work with this before)
 
 [1.1.1] - 2020-07-21
 ~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Unreleased
 Removed
 _______
 
-* Support for Python 3.5.  Versions 3.5.3 and above will likely still work for now, but they are no longer being tested; this lets us upgrade some dependencies and avoid confusion when aiohttp fails to install under 3.5.2 and below.  Python 3.5 reaches EOL in 1 month anyway.
+* Removed support for Python 3.5.  Versions 3.5.3 and above will likely still work for now, but they are no longer being tested; this lets us upgrade some dependencies and avoid confusion when aiohttp fails to install under 3.5.2 and below.  Python 3.5 reaches EOL in 1 month anyway.
 
 Fixed
 _____

--- a/pytest_repo_health/__init__.py
+++ b/pytest_repo_health/__init__.py
@@ -5,7 +5,7 @@ and outputting report based on data gathered during checks.
 """
 
 
-__version__ = "1.1.1"
+__version__ = "2.0.0"
 
 
 def health_metadata(parent_path, output_keys):

--- a/pytest_repo_health/fixtures/github.py
+++ b/pytest_repo_health/fixtures/github.py
@@ -5,10 +5,15 @@ import os
 import re
 
 import pytest
-from github import GitHub
+try:
+    # github.py > 0.5.0
+    from github import Client
+except ImportError:
+    # github.py 0.5.0
+    from github import GitHub as Client
 from github.errors import GitHubError
 
-URL_PATTERN = r"github.com[/:](?P<org_name>[^/]+)/(?P<repo_name>[^/\.]+)"
+URL_PATTERN = r"github.com[/:](?P<org_name>[^/]+)/(?P<repo_name>[^/]+).git"
 
 
 @pytest.fixture(scope="session")
@@ -22,7 +27,7 @@ def github_client():
     except KeyError:
         raise Exception("To use any of the GitHub fixtures, you must set the GITHUB_TOKEN environment variable "
                         "to contain a GitHub personal access token.")
-    return GitHub(token)
+    return Client(token)
 
 
 @pytest.fixture

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 # Core requirements for using this application
 -c constraints.txt
+-r github.in
 
-github.py                 # GitHub API bindings for the GitHub repository data fixtures
 GitPython                 # Python wrapper for the git binary, for the git repository data fixtures
 pytest                    # Framework used to find and execute each "opynion"
 pytest-aiohttp            # Async test support, needed to use the github.py package for the GitHub API fixtures

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
 gitdb==4.0.5              # via gitpython
-github.py==0.5.0          # via -r requirements/base.in
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/github.in
 gitpython==3.1.7          # via -r requirements/base.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, yarl

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
 gitdb==4.0.5              # via gitpython
-git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/github.in
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/github.in
 gitpython==3.1.7          # via -r requirements/base.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, yarl

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,7 +20,7 @@ distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 edx-lint==1.5.0           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/quality.txt, gitpython
-git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/quality.txt
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/quality.txt
 gitpython==3.1.7          # via -r requirements/quality.txt
 idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, requests, yarl

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,7 +20,7 @@ distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 edx-lint==1.5.0           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/quality.txt, gitpython
-github.py==0.5.0          # via -r requirements/quality.txt
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/quality.txt
 gitpython==3.1.7          # via -r requirements/quality.txt
 idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, requests, yarl

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -17,7 +17,7 @@ doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
-github.py==0.5.0          # via -r requirements/test.txt
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/test.txt
 gitpython==3.1.7          # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -17,7 +17,7 @@ doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
-git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/test.txt
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/test.txt
 gitpython==3.1.7          # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -1,0 +1,58 @@
+# DON'T JUST ADD NEW DEPENDENCIES!!!
+#
+# If you open a pull request that adds a new dependency, you should:
+#   * verify that the dependency has a license compatible with AGPLv3
+#   * confirm that it has no system requirements beyond what we already install
+#   * run "make upgrade" to update the detailed requirements files
+#
+# Do *NOT* install Python packages from GitHub unless it's absolutely necessary!
+# "I don't have time to add automatic Travis upload to PyPI." is *not* an
+# acceptable excuse. Non-wheel module installations slow down the dev/building process.
+# Travis/PyPI instructions are here:
+# https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/41911049/Publishing+a+Package+to+PyPI+using+Travis
+#
+# A correct GitHub reference looks like this:
+#
+#   git+https://github.com/OWNER/REPO-NAME.git@TAG-OR-SHA#egg=DIST-NAME==VERSION
+#
+# For example:
+#
+#   git+https://github.com/edx/edx-lint.git@v0.3.2#egg=edx_lint==0.3.2
+#
+# where:
+#
+#   OWNER = edx
+#   REPO-NAME = edx-lint
+#   TAG-OR-SHA = v0.3.2
+#   DIST-NAME = edx_lint
+#   VERSION = 0.3.2
+#
+#
+# Rules to follow (even though many URLs here don't follow them!):
+#
+#   * Don't leave out any of these pieces.
+#
+#   * TAG-OR-SHA is the specific commit to install.  It must be a git tag,
+#     or a git SHA commit hash.  Don't use branch names here.  If OWNER is
+#     not an edX organization, then it must be a SHA.  If you use a SHA,
+#     please make sure there is a tag associated with it, so the commit can't
+#     be lost during rebase.
+#
+#   * DIST-NAME is the distribution name, the same name you'd use in a
+#     "pip install" command.  It might be different than REPO-NAME. It must
+#     be the same as the `name="DIST-NAME"` value in the repo's setup.py.
+#
+#   * VERSION might not be the same as TAG-OR-SHA, but if the tag names the
+#     version, please make it match the VERSION, but with a "v" prefix.
+#     VERSION must be the same as the `version="VERSION"` value in the repo's
+#     setup.py.  An alternative is to use 0.0 as VERSION: this forces pip to
+#     re-install the package each time, and can be useful when working with two
+#     repos before picking a version number. Don't use 0.0 on master, only for
+#     tight-loop work in progress.
+
+
+# Python libraries to install directly from github
+
+# GitHub API bindings for the GitHub repository data fixtures
+# The PyPI release (0.5.0) chokes on parsing a repo's code of conduct
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -55,4 +55,4 @@
 
 # GitHub API bindings for the GitHub repository data fixtures
 # The PyPI release (0.5.0) chokes on parsing a repo's code of conduct
-git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,7 +14,7 @@ click==7.1.2              # via click-log, edx-lint
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
 edx-lint==1.5.0           # via -r requirements/quality.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
-git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/test.txt
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/test.txt
 gitpython==3.1.7          # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, yarl

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,7 +14,7 @@ click==7.1.2              # via click-log, edx-lint
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
 edx-lint==1.5.0           # via -r requirements/quality.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
-github.py==0.5.0          # via -r requirements/test.txt
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/test.txt
 gitpython==3.1.7          # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, yarl

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ attrs==19.3.0             # via -r requirements/base.txt, aiohttp, pytest
 chardet==3.0.4            # via -r requirements/base.txt, aiohttp
 coverage==5.2.1           # via pytest-cov
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
-git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/base.txt
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/base.txt
 gitpython==3.1.7          # via -r requirements/base.txt
 idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
 idna==2.10                # via -r requirements/base.txt, idna-ssl, yarl

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ attrs==19.3.0             # via -r requirements/base.txt, aiohttp, pytest
 chardet==3.0.4            # via -r requirements/base.txt, aiohttp
 coverage==5.2.1           # via pytest-cov
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
-github.py==0.5.0          # via -r requirements/base.txt
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py  # via -r requirements/base.txt
 gitpython==3.1.7          # via -r requirements/base.txt
 idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
 idna==2.10                # via -r requirements/base.txt, idna-ssl, yarl


### PR DESCRIPTION
Upgrade github.py to fix a bug with code of conduct parsing, and fix the git origin URL regex to handle repos with names like `.github` and `github.py`.  Make a new release, which is a major version bump due to the previously-committed drop of Python 3.5 support.