### PR TITLE
Pin importlib-meteadata to 1.7.0 for python36

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3
 gitpython==3.1.8          # via -r requirements/base.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, yarl
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 more-itertools==8.5.0     # via pytest
 multidict==4.7.6          # via aiohttp, yarl
@@ -28,5 +28,5 @@ six==1.15.0               # via packaging
 smmap==3.0.4              # via gitdb
 toml==0.10.1              # via pytest
 typing-extensions==3.7.4.3  # via aiohttp, yarl
-yarl==1.5.1               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
+yarl==1.6.0               # via aiohttp
+zipp==3.2.0               # via importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,6 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python36
+importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
 codecov==2.1.9            # via -r requirements/travis.txt
 coverage==5.3             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
-diff-cover==4.0.0         # via -r requirements/dev.in
+diff-cover==4.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 edx-lint==1.5.2           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
@@ -24,7 +24,7 @@ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3
 gitpython==3.1.8          # via -r requirements/quality.txt
 idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 inflect==4.1.0            # via jinja2-pluralize
 iniconfig==1.0.1          # via -r requirements/quality.txt, pytest
@@ -42,7 +42,7 @@ pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/tra
 py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pydocstyle==5.1.1         # via -r requirements/quality.txt
-pygments==2.7.0           # via diff-cover
+pygments==2.7.1           # via diff-cover
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
@@ -64,8 +64,8 @@ typing-extensions==3.7.4.3  # via -r requirements/quality.txt, aiohttp, yarl
 urllib3==1.25.10          # via -r requirements/travis.txt, requests
 virtualenv==20.0.31       # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-yarl==1.5.1               # via -r requirements/quality.txt, aiohttp
-zipp==3.1.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
+yarl==1.6.0               # via -r requirements/quality.txt, aiohttp
+zipp==3.2.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -9,7 +9,7 @@ alabaster==0.7.12         # via sphinx
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==20.2.0             # via -r requirements/test.txt, aiohttp, pytest
 babel==2.8.0              # via sphinx
-bleach==3.1.5             # via readme-renderer
+bleach==3.2.1             # via readme-renderer
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via -r requirements/test.txt, aiohttp, doc8, requests
 coverage==5.3             # via -r requirements/test.txt, pytest-cov
@@ -22,7 +22,7 @@ gitpython==3.1.8          # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, stevedore
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest, stevedore
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
@@ -32,7 +32,7 @@ packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
 pbr==5.5.0                # via stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
-pygments==2.7.0           # via doc8, readme-renderer, sphinx
+pygments==2.7.1           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt
 pytest-cov==2.10.1        # via -r requirements/test.txt
@@ -57,8 +57,8 @@ toml==0.10.1              # via -r requirements/test.txt, pytest
 typing-extensions==3.7.4.3  # via -r requirements/test.txt, aiohttp, yarl
 urllib3==1.25.10          # via requests
 webencodings==0.5.1       # via bleach
-yarl==1.5.1               # via -r requirements/test.txt, aiohttp
-zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
+yarl==1.6.0               # via -r requirements/test.txt, aiohttp
+zipp==3.2.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -18,7 +18,7 @@ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3
 gitpython==3.1.8          # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, yarl
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
@@ -46,5 +46,5 @@ toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/test.txt, aiohttp, yarl
 wrapt==1.11.2             # via astroid
-yarl==1.5.1               # via -r requirements/test.txt, aiohttp
-zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
+yarl==1.6.0               # via -r requirements/test.txt, aiohttp
+zipp==3.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3
 gitpython==3.1.8          # via -r requirements/base.txt
 idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
 idna==2.10                # via -r requirements/base.txt, idna-ssl, yarl
-importlib-metadata==1.7.0  # via -r requirements/base.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/base.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/base.txt, pytest
 more-itertools==8.5.0     # via -r requirements/base.txt, pytest
 multidict==4.7.6          # via -r requirements/base.txt, aiohttp, yarl
@@ -30,5 +30,5 @@ six==1.15.0               # via -r requirements/base.txt, packaging
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
 toml==0.10.1              # via -r requirements/base.txt, pytest
 typing-extensions==3.7.4.3  # via -r requirements/base.txt, aiohttp, yarl
-yarl==1.5.1               # via -r requirements/base.txt, aiohttp
-zipp==3.1.0               # via -r requirements/base.txt, importlib-metadata
+yarl==1.6.0               # via -r requirements/base.txt, aiohttp
+zipp==3.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,7 @@ coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -25,4 +25,4 @@ tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.20.0               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.10          # via requests
 virtualenv==20.0.31       # via tox
-zipp==3.1.0               # via importlib-metadata, importlib-resources
+zipp==3.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
- Pinned `importlib-metadata==1.7.0` as `version>1.7.0` is causing conflicts for python36 in running `make upgrade`.
