### PR TITLE
ARCHBOM-1475: Added ability to name metadata output file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.1.0] - 2020-11-03
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Added ability to set filename for checks metadata file. You can now give a file path after --repo-health-metadata flag
+
 [2.0.1] - 2020-08-12
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Arguments added by plugin::
 
   --output-path <file path> : path to where to save resulting checks report
 
-  --repo-health-metadata: if the is present, plugin will collect metadata(docs) from checks and output them as a metadata.yaml file
+  --repo-health-metadata: if the is present, plugin will collect metadata(docs) from checks. You can give filename after flag(if no filename, it defaults to metadata.yaml)
 
 Plugin Enhancement path
 ------------------------

--- a/pytest_repo_health/__init__.py
+++ b/pytest_repo_health/__init__.py
@@ -5,7 +5,7 @@ and outputting report based on data gathered during checks.
 """
 
 
-__version__ = "2.0.4"
+__version__ = "2.1.0"
 
 
 def health_metadata(parent_path, output_keys):

--- a/pytest_repo_health/__init__.py
+++ b/pytest_repo_health/__init__.py
@@ -5,7 +5,7 @@ and outputting report based on data gathered during checks.
 """
 
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 
 def health_metadata(parent_path, output_keys):

--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -93,7 +93,7 @@ def pytest_addoption(parser):
         dest='repo_health_metadata',
         nargs='?',
         default=False,
-        const="metadata.yaml"
+        const="metadata.yaml",
         help="if true, plugin will collect repo health metadata from each check"
     )
 

--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -90,9 +90,10 @@ def pytest_addoption(parser):
 
     group.addoption(
         "--repo-health-metadata",
-        action="store_true",
         dest='repo_health_metadata',
+        nargs='?',
         default=False,
+        const="metadata.yaml"
         help="if true, plugin will collect repo health metadata from each check"
     )
 
@@ -163,7 +164,7 @@ def pytest_collection_modifyitems(session, config, items):
                 # add doc string if function also has doc string
                 if item.function.__doc__ is not None:
                     checks_metadata[module_name][item.name]["doc_string"] = item.function.__doc__.strip()
-        with open("metadata.yaml", "w") as write_file:
+        with open(config.getoption("repo_health_metadata"), "w") as write_file:
             yaml.dump(checks_metadata, write_file, indent=4)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 PYTEST_INI = """
 [pytest]
-addopts = --repo-health --repo-health-path {checks_path} --repo-path {repo_path} --repo-health-metadata
+addopts = --repo-health --repo-health-path {checks_path} --repo-path {repo_path} --repo-health-metadata {metadata_path}
 """
 
 
-def run_checks(testdir, repo_path=None, **kwargs):
+def run_checks(testdir, repo_path=None, metadata_path=None, **kwargs):
     """
     Put the check file content for each provided kwarg key into check files under the
     specified test directory, and then run them.  Runs the checks against the root of
@@ -27,7 +27,10 @@ def run_checks(testdir, repo_path=None, **kwargs):
             f.write(content)
     if repo_path is None:
         repo_path = Path(__file__).parent / ".."
+    if metadata_path is None:
+        metadata_path = ""
     # Tell pytest where to find the checks and to run them on the real repository root
     testdir.makefile(".ini", pytest=PYTEST_INI.format(checks_path=str(checks_path),
-                                                      repo_path=str(repo_path)))
+                                                      repo_path=str(repo_path),
+                                                      metadata_path=metadata_path))
     return testdir.runpytest()

--- a/tests/test_repo_health.py
+++ b/tests/test_repo_health.py
@@ -33,3 +33,8 @@ def test_create_report(testdir):
     result = run_checks(testdir, test_collection=TEST_COLLECTION)
     result.assert_outcomes(passed=1)
     assert (testdir.tmpdir / 'repo_health.yaml').exists()
+
+def test_metadata(testdir):
+    result = run_checks(testdir, metadata_path='test_metadata.yaml', test_collection=TEST_COLLECTION)
+    result.assert_outcomes(passed=1)
+    assert (testdir.tmpdir / 'test_metadata.yaml').exists()


### PR DESCRIPTION
Previously, there was no way to change the file to which metadata was written. This PR adds this ability.