### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ pytest-repo-health
     :target: https://pypi.org/project/pytest-repo-health
     :alt: Python versions
 
-.. image:: https://travis-ci.org/edx/pytest-repo-health.svg?branch=master
-    :target: https://travis-ci.org/edx/pytest-repo-health
+.. image:: https://travis-ci.com/edx/pytest-repo-health.svg?branch=master
+    :target: https://travis-ci.com/edx/pytest-repo-health
     :alt: See Build Status on Travis CI
 
 .. image:: https://ci.appveyor.com/api/projects/status/github/edx/pytest-repo-health?branch=master


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089