### PR TITLE
Pinned importlib-metadata<3.0 because of Tox and Virtualenv

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.7.2            # via github.py, pytest-aiohttp
+aiohttp==3.7.3            # via github.py, pytest-aiohttp
 async-timeout==3.0.1      # via aiohttp
 attrs==20.3.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
@@ -13,17 +13,16 @@ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3
 gitpython==3.1.11         # via -r requirements/base.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, yarl
-importlib-metadata==2.0.0  # via pluggy, pytest
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 multidict==5.0.2          # via aiohttp, yarl
-packaging==20.4           # via pytest
+packaging==20.7           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via -r requirements/base.in
 pytest==6.1.2             # via -r requirements/base.in, pytest-aiohttp
 pyyaml==5.3.1             # via -r requirements/base.in
-six==1.15.0               # via packaging
 smmap==3.0.4              # via gitdb
 toml==0.10.2              # via pytest
 typing-extensions==3.7.4.3  # via aiohttp, yarl

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,8 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+# Tox and virtualenv require importlib-metadata<3.0 to support python3.5
+# so pinning until both packages drop support for python3.5 &
+# update their required importlib-metadata version constraint
+importlib-metadata<3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.7.2            # via -r requirements/quality.txt, github.py, pytest-aiohttp
+aiohttp==3.7.3            # via -r requirements/quality.txt, github.py, pytest-aiohttp
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
 async-timeout==3.0.1      # via -r requirements/quality.txt, aiohttp
@@ -24,7 +24,7 @@ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3
 gitpython==3.1.11         # via -r requirements/quality.txt
 idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.3.0  # via -r requirements/travis.txt, virtualenv
 inflect==5.0.2            # via jinja2-pluralize
 iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
@@ -35,8 +35,8 @@ lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 multidict==5.0.2          # via -r requirements/quality.txt, aiohttp, yarl
-packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
-pip-tools==5.3.1          # via -r requirements/pip-tools.txt
+packaging==20.7           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+pip-tools==5.4.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
@@ -52,7 +52,7 @@ pytest-cov==2.10.1        # via -r requirements/quality.txt
 pytest==6.1.2             # via -r requirements/quality.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/quality.txt
 requests==2.25.0          # via -r requirements/travis.txt, codecov
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-lint, packaging, pip-tools, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-lint, pip-tools, tox, virtualenv
 smmap==3.0.4              # via -r requirements/quality.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
@@ -61,7 +61,7 @@ tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 typing-extensions==3.7.4.3  # via -r requirements/quality.txt, aiohttp, yarl
 urllib3==1.26.2           # via -r requirements/travis.txt, requests
-virtualenv==20.1.0        # via -r requirements/travis.txt, tox
+virtualenv==20.2.1        # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
 yarl==1.6.3               # via -r requirements/quality.txt, aiohttp
 zipp==3.4.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.7.2            # via -r requirements/test.txt, github.py, pytest-aiohttp
+aiohttp==3.7.3            # via -r requirements/test.txt, github.py, pytest-aiohttp
 alabaster==0.7.12         # via sphinx
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==20.3.0             # via -r requirements/test.txt, aiohttp, pytest
@@ -22,12 +22,12 @@ gitpython==3.1.11         # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest, stevedore
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest, stevedore
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 multidict==5.0.2          # via -r requirements/test.txt, aiohttp, yarl
-packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
+packaging==20.7           # via -r requirements/test.txt, bleach, pytest, sphinx
 pbr==5.5.1                # via stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
@@ -40,8 +40,8 @@ pytz==2020.4              # via babel
 pyyaml==5.3.1             # via -r requirements/test.txt
 readme-renderer==28.0     # via -r requirements/doc.in
 requests==2.25.0          # via sphinx
-restructuredtext-lint==1.3.1  # via doc8
-six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, packaging, readme-renderer
+restructuredtext-lint==1.3.2  # via doc8
+six==1.15.0               # via bleach, doc8, edx-sphinx-theme, readme-renderer
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
 sphinx==3.3.1             # via -r requirements/doc.in, edx-sphinx-theme

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
+pip-tools==5.4.0          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.7.2            # via -r requirements/test.txt, github.py, pytest-aiohttp
+aiohttp==3.7.3            # via -r requirements/test.txt, github.py, pytest-aiohttp
 astroid==2.3.3            # via pylint, pylint-celery
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==20.3.0             # via -r requirements/test.txt, aiohttp, pytest
@@ -18,13 +18,13 @@ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3
 gitpython==3.1.11         # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, yarl
-importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 multidict==5.0.2          # via -r requirements/test.txt, aiohttp, yarl
-packaging==20.4           # via -r requirements/test.txt, pytest
+packaging==20.7           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
@@ -38,7 +38,7 @@ pytest-aiohttp==0.3.0     # via -r requirements/test.txt
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/test.txt
-six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, packaging
+six==1.15.0               # via astroid, edx-lint
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via pydocstyle
 toml==0.10.2              # via -r requirements/test.txt, pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.7.2            # via -r requirements/base.txt, github.py, pytest-aiohttp
+aiohttp==3.7.3            # via -r requirements/base.txt, github.py, pytest-aiohttp
 async-timeout==3.0.1      # via -r requirements/base.txt, aiohttp
 attrs==20.3.0             # via -r requirements/base.txt, aiohttp, pytest
 chardet==3.0.4            # via -r requirements/base.txt, aiohttp
@@ -14,10 +14,10 @@ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3
 gitpython==3.1.11         # via -r requirements/base.txt
 idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
 idna==2.10                # via -r requirements/base.txt, idna-ssl, yarl
-importlib-metadata==2.0.0  # via -r requirements/base.txt, pluggy, pytest
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/base.txt, pytest
 multidict==5.0.2          # via -r requirements/base.txt, aiohttp, yarl
-packaging==20.4           # via -r requirements/base.txt, pytest
+packaging==20.7           # via -r requirements/base.txt, pytest
 pluggy==0.13.1            # via -r requirements/base.txt, pytest
 py==1.9.0                 # via -r requirements/base.txt, pytest
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
@@ -25,7 +25,6 @@ pytest-aiohttp==0.3.0     # via -r requirements/base.txt
 pytest-cov==2.10.1        # via -r requirements/test.in
 pytest==6.1.2             # via -r requirements/base.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/base.txt
-six==1.15.0               # via -r requirements/base.txt, packaging
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
 toml==0.10.2              # via -r requirements/base.txt, pytest
 typing-extensions==3.7.4.3  # via -r requirements/base.txt, aiohttp, yarl

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,17 +12,17 @@ coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.3.0  # via virtualenv
-packaging==20.4           # via tox
+packaging==20.7           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 requests==2.25.0          # via codecov
-six==1.15.0               # via packaging, tox, virtualenv
+six==1.15.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.20.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.26.2           # via requests
-virtualenv==20.1.0        # via tox
+virtualenv==20.2.1        # via tox
 zipp==3.4.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
`importlib-metadata>3.0` dropped support for `python3.5` but `Tox` and `virtualenv` require `importlib-metadata<3.0` to support `python3.5` so pinning until both packages drop support for `python3.5` & update their required `importlib-metadata` version constraint.