### PR TITLE
Pinned chardet<4.0 version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@
 aiohttp==3.7.3            # via github.py, pytest-aiohttp
 async-timeout==3.0.1      # via aiohttp
 attrs==20.3.0             # via aiohttp, pytest
-chardet==3.0.4            # via aiohttp
+chardet==3.0.4            # via -c requirements/constraints.txt, aiohttp
 gitdb==4.0.5              # via gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/github.in
 gitpython==3.1.11         # via -r requirements/base.in
@@ -16,12 +16,12 @@ idna==2.10                # via idna-ssl, yarl
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 multidict==5.1.0          # via aiohttp, yarl
-packaging==20.7           # via pytest
+packaging==20.8           # via pytest
 pluggy==0.13.1            # via pytest
-py==1.9.0                 # via pytest
+py==1.10.0                # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via -r requirements/base.in
-pytest==6.1.2             # via -r requirements/base.in, pytest-aiohttp
+pytest==6.2.1             # via -r requirements/base.in, pytest-aiohttp
 pyyaml==5.3.1             # via -r requirements/base.in
 smmap==3.0.4              # via gitdb
 toml==0.10.2              # via pytest

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -5,24 +5,24 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
-certifi==2020.11.8        # via requests
-chardet==3.0.4            # via requests
-codecov==2.1.10           # via -r requirements/ci.in
-coverage==5.3             # via codecov
+certifi==2020.12.5        # via requests
+chardet==3.0.4            # via -c requirements/constraints.txt, requests
+codecov==2.1.11           # via -r requirements/ci.in
+coverage==5.3.1           # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
-importlib-resources==3.3.0  # via virtualenv
-packaging==20.7           # via tox
+importlib-resources==3.3.1  # via virtualenv
+packaging==20.8           # via tox
 pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
+py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.25.0          # via codecov
+requests==2.25.1          # via codecov
 six==1.15.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/ci.in
 tox==3.20.1               # via -r requirements/ci.in, tox-battery
 urllib3==1.26.2           # via requests
-virtualenv==20.2.1        # via tox
+virtualenv==20.2.2        # via tox
 zipp==3.4.0               # via importlib-metadata, importlib-resources

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,3 +12,6 @@
 # so pinning until both packages drop support for python3.5 &
 # update their required importlib-metadata version constraint
 importlib-metadata<3.0
+
+# aiohttp latest version 3.7.3 requires chardet<4.0, can be removed once aiohttp==4.0.0 is released.
+chardet<4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,18 +6,18 @@
 #
 aiohttp==3.7.3            # via -r requirements/quality.txt, github.py, pytest-aiohttp
 appdirs==1.4.4            # via -r requirements/ci.txt, virtualenv
-astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
+astroid==2.4.2            # via -r requirements/quality.txt, pylint, pylint-celery
 async-timeout==3.0.1      # via -r requirements/quality.txt, aiohttp
 attrs==20.3.0             # via -r requirements/quality.txt, aiohttp, pytest
-certifi==2020.11.8        # via -r requirements/ci.txt, requests
-chardet==3.0.4            # via -r requirements/ci.txt, -r requirements/quality.txt, aiohttp, requests
+certifi==2020.12.5        # via -r requirements/ci.txt, requests
+chardet==3.0.4            # via -c requirements/constraints.txt, -r requirements/ci.txt, -r requirements/quality.txt, aiohttp, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
-codecov==2.1.10           # via -r requirements/ci.txt
-coverage==5.3             # via -r requirements/ci.txt, -r requirements/quality.txt, codecov, pytest-cov
+codecov==2.1.11           # via -r requirements/ci.txt
+coverage==5.3.1           # via -r requirements/ci.txt, -r requirements/quality.txt, codecov, pytest-cov
 diff-cover==4.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/ci.txt, virtualenv
-edx-lint==1.5.2           # via -r requirements/quality.txt
+edx-lint==1.6             # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/ci.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/quality.txt, gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/quality.txt
@@ -25,44 +25,44 @@ gitpython==3.1.11         # via -r requirements/quality.txt
 idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
 idna==2.10                # via -r requirements/ci.txt, -r requirements/quality.txt, idna-ssl, requests, yarl
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, -r requirements/ci.txt, -r requirements/quality.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.3.0  # via -r requirements/ci.txt, virtualenv
+importlib-resources==3.3.1  # via -r requirements/ci.txt, virtualenv
 inflect==5.0.2            # via jinja2-pluralize
 iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
-isort==4.3.21             # via -r requirements/quality.txt, pylint
+isort==5.6.4              # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 multidict==5.1.0          # via -r requirements/quality.txt, aiohttp, yarl
-packaging==20.7           # via -r requirements/ci.txt, -r requirements/quality.txt, pytest, tox
+packaging==20.8           # via -r requirements/ci.txt, -r requirements/quality.txt, pytest, tox
 pip-tools==5.4.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/ci.txt, -r requirements/quality.txt, diff-cover, pytest, tox
-py==1.9.0                 # via -r requirements/ci.txt, -r requirements/quality.txt, pytest, tox
+py==1.10.0                # via -r requirements/ci.txt, -r requirements/quality.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pydocstyle==5.1.1         # via -r requirements/quality.txt
-pygments==2.7.2           # via diff-cover
+pygments==2.7.3           # via diff-cover
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/ci.txt, -r requirements/quality.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/quality.txt
 pytest-cov==2.10.1        # via -r requirements/quality.txt
-pytest==6.1.2             # via -r requirements/quality.txt, pytest-aiohttp, pytest-cov
+pytest==6.2.1             # via -r requirements/quality.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/quality.txt
-requests==2.25.0          # via -r requirements/ci.txt, codecov
+requests==2.25.1          # via -r requirements/ci.txt, codecov
 six==1.15.0               # via -r requirements/ci.txt, -r requirements/pip-tools.txt, -r requirements/quality.txt, astroid, edx-lint, pip-tools, tox, virtualenv
 smmap==3.0.4              # via -r requirements/quality.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
-toml==0.10.2              # via -r requirements/ci.txt, -r requirements/quality.txt, pytest, tox
+toml==0.10.2              # via -r requirements/ci.txt, -r requirements/quality.txt, pylint, pytest, tox
 tox-battery==0.6.1        # via -r requirements/ci.txt
 tox==3.20.1               # via -r requirements/ci.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 typing-extensions==3.7.4.3  # via -r requirements/quality.txt, aiohttp, yarl
 urllib3==1.26.2           # via -r requirements/ci.txt, requests
-virtualenv==20.2.1        # via -r requirements/ci.txt, tox
-wrapt==1.11.2             # via -r requirements/quality.txt, astroid
+virtualenv==20.2.2        # via -r requirements/ci.txt, tox
+wrapt==1.12.1             # via -r requirements/quality.txt, astroid
 yarl==1.6.3               # via -r requirements/quality.txt, aiohttp
 zipp==3.4.0               # via -r requirements/ci.txt, -r requirements/quality.txt, importlib-metadata, importlib-resources
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,12 +10,12 @@ async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==20.3.0             # via -r requirements/test.txt, aiohttp, pytest
 babel==2.9.0              # via sphinx
 bleach==3.2.1             # via readme-renderer
-certifi==2020.11.8        # via requests
-chardet==3.0.4            # via -r requirements/test.txt, aiohttp, doc8, requests
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
+certifi==2020.12.5        # via requests
+chardet==3.0.4            # via -c requirements/constraints.txt, -r requirements/test.txt, aiohttp, doc8, requests
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/test.txt
 gitpython==3.1.11         # via -r requirements/test.txt
@@ -27,24 +27,24 @@ iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 multidict==5.1.0          # via -r requirements/test.txt, aiohttp, yarl
-packaging==20.7           # via -r requirements/test.txt, bleach, pytest, sphinx
+packaging==20.8           # via -r requirements/test.txt, bleach, pytest, sphinx
 pbr==5.5.1                # via stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.9.0                 # via -r requirements/test.txt, pytest
-pygments==2.7.2           # via doc8, readme-renderer, sphinx
+py==1.10.0                # via -r requirements/test.txt, pytest
+pygments==2.7.3           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest==6.1.2             # via -r requirements/test.txt, pytest-aiohttp, pytest-cov
+pytest==6.2.1             # via -r requirements/test.txt, pytest-aiohttp, pytest-cov
 pytz==2020.4              # via babel
 pyyaml==5.3.1             # via -r requirements/test.txt
 readme-renderer==28.0     # via -r requirements/doc.in
-requests==2.25.0          # via sphinx
+requests==2.25.1          # via sphinx
 restructuredtext-lint==1.3.2  # via doc8
 six==1.15.0               # via bleach, doc8, edx-sphinx-theme, readme-renderer
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.3.1             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.4.0             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-wheel==0.36.0             # via -r requirements/pip.in
+wheel==0.36.2             # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.1               # via -r requirements/pip.in
-setuptools==50.3.2        # via -r requirements/pip.in
+pip==20.3.3               # via -r requirements/pip.in
+setuptools==51.1.0        # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,14 +5,14 @@
 #    make upgrade
 #
 aiohttp==3.7.3            # via -r requirements/test.txt, github.py, pytest-aiohttp
-astroid==2.3.3            # via pylint, pylint-celery
+astroid==2.4.2            # via pylint, pylint-celery
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==20.3.0             # via -r requirements/test.txt, aiohttp, pytest
-chardet==3.0.4            # via -r requirements/test.txt, aiohttp
+chardet==3.0.4            # via -c requirements/constraints.txt, -r requirements/test.txt, aiohttp
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
-edx-lint==1.5.2           # via -r requirements/quality.in
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
+edx-lint==1.6             # via -r requirements/quality.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/test.txt
 gitpython==3.1.11         # via -r requirements/test.txt
@@ -20,30 +20,30 @@ idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, yarl
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/quality.in, pylint
+isort==5.6.4              # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 multidict==5.1.0          # via -r requirements/test.txt, aiohttp, yarl
-packaging==20.7           # via -r requirements/test.txt, pytest
+packaging==20.8           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.9.0                 # via -r requirements/test.txt, pytest
+py==1.10.0                # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pydocstyle==5.1.1         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest==6.1.2             # via -r requirements/test.txt, pytest-aiohttp, pytest-cov
+pytest==6.2.1             # via -r requirements/test.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/test.txt
 six==1.15.0               # via astroid, edx-lint
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via pydocstyle
-toml==0.10.2              # via -r requirements/test.txt, pytest
+toml==0.10.2              # via -r requirements/test.txt, pylint, pytest
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/test.txt, aiohttp, yarl
-wrapt==1.11.2             # via astroid
+wrapt==1.12.1             # via astroid
 yarl==1.6.3               # via -r requirements/test.txt, aiohttp
 zipp==3.4.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,8 +7,8 @@
 aiohttp==3.7.3            # via -r requirements/base.txt, github.py, pytest-aiohttp
 async-timeout==3.0.1      # via -r requirements/base.txt, aiohttp
 attrs==20.3.0             # via -r requirements/base.txt, aiohttp, pytest
-chardet==3.0.4            # via -r requirements/base.txt, aiohttp
-coverage==5.3             # via pytest-cov
+chardet==3.0.4            # via -c requirements/constraints.txt, -r requirements/base.txt, aiohttp
+coverage==5.3.1           # via pytest-cov
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/base.txt
 gitpython==3.1.11         # via -r requirements/base.txt
@@ -17,13 +17,13 @@ idna==2.10                # via -r requirements/base.txt, idna-ssl, yarl
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, -r requirements/base.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/base.txt, pytest
 multidict==5.1.0          # via -r requirements/base.txt, aiohttp, yarl
-packaging==20.7           # via -r requirements/base.txt, pytest
+packaging==20.8           # via -r requirements/base.txt, pytest
 pluggy==0.13.1            # via -r requirements/base.txt, pytest
-py==1.9.0                 # via -r requirements/base.txt, pytest
+py==1.10.0                # via -r requirements/base.txt, pytest
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/base.txt
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest==6.1.2             # via -r requirements/base.txt, pytest-aiohttp, pytest-cov
+pytest==6.2.1             # via -r requirements/base.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/base.txt
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
 toml==0.10.2              # via -r requirements/base.txt, pytest


### PR DESCRIPTION
`aiohttp==3.7.3(latest release)` requires [`chardet<4.0`](https://github.com/aio-libs/aiohttp/blob/2f655a59d0daedfa2a794996c4355b576c98ecc8/setup.py#L69) which is causing conflicts in make upgrade. Pinning the version in constraints until `aiohttp==4.0.0(pre-release available right now)` is released. 