### PR TITLE
Pin idna<3 due to requests package

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,9 @@ attrs==20.3.0             # via aiohttp, pytest
 chardet==3.0.4            # via -c requirements/constraints.txt, aiohttp
 gitdb==4.0.5              # via gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/github.in
-gitpython==3.1.11         # via -r requirements/base.in
+gitpython==3.1.12         # via -r requirements/base.in
 idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, yarl
+idna==2.10                # via -c requirements/constraints.txt, idna-ssl, yarl
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 multidict==5.1.0          # via aiohttp, yarl

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -11,7 +11,7 @@ codecov==2.1.11           # via -r requirements/ci.in
 coverage==5.3.1           # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-idna==2.10                # via requests
+idna==2.10                # via -c requirements/constraints.txt, requests
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==4.1.1  # via virtualenv
 packaging==20.8           # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,3 +15,6 @@ importlib-metadata<3.0
 
 # aiohttp latest version 3.7.3 requires chardet<4.0, can be removed once aiohttp==4.0.0 is released.
 chardet<4.0
+
+# requests has a constraint idna<3 in it, so pinning it unless requests updates the constraint
+idna<3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,14 +21,14 @@ edx-lint==1.6             # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/ci.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/quality.txt, gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/quality.txt
-gitpython==3.1.11         # via -r requirements/quality.txt
+gitpython==3.1.12         # via -r requirements/quality.txt
 idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
-idna==2.10                # via -r requirements/ci.txt, -r requirements/quality.txt, idna-ssl, requests, yarl
+idna==2.10                # via -c requirements/constraints.txt, -r requirements/ci.txt, -r requirements/quality.txt, idna-ssl, requests, yarl
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, -r requirements/ci.txt, -r requirements/quality.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==4.1.1  # via -r requirements/ci.txt, virtualenv
 inflect==5.0.2            # via jinja2-pluralize
 iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
-isort==5.6.4              # via -r requirements/quality.txt, pylint
+isort==5.7.0              # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
@@ -36,7 +36,7 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 multidict==5.1.0          # via -r requirements/quality.txt, aiohttp, yarl
 packaging==20.8           # via -r requirements/ci.txt, -r requirements/quality.txt, pytest, tox
-pip-tools==5.4.0          # via -r requirements/pip-tools.txt
+pip-tools==5.5.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/ci.txt, -r requirements/quality.txt, diff-cover, pytest, tox
 py==1.10.0                # via -r requirements/ci.txt, -r requirements/quality.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
@@ -52,13 +52,13 @@ pytest-cov==2.10.1        # via -r requirements/quality.txt
 pytest==6.2.1             # via -r requirements/quality.txt, pytest-aiohttp, pytest-cov
 pyyaml==5.3.1             # via -r requirements/quality.txt
 requests==2.25.1          # via -r requirements/ci.txt, codecov
-six==1.15.0               # via -r requirements/ci.txt, -r requirements/pip-tools.txt, -r requirements/quality.txt, astroid, edx-lint, pip-tools, tox, virtualenv
+six==1.15.0               # via -r requirements/ci.txt, -r requirements/quality.txt, astroid, edx-lint, tox, virtualenv
 smmap==3.0.4              # via -r requirements/quality.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 toml==0.10.2              # via -r requirements/ci.txt, -r requirements/quality.txt, pylint, pytest, tox
 tox-battery==0.6.1        # via -r requirements/ci.txt
 tox==3.20.1               # via -r requirements/ci.txt, tox-battery
-typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
+typed-ast==1.4.2          # via -r requirements/quality.txt, astroid
 typing-extensions==3.7.4.3  # via -r requirements/quality.txt, aiohttp, yarl
 urllib3==1.26.2           # via -r requirements/ci.txt, requests
 virtualenv==20.2.2        # via -r requirements/ci.txt, tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,9 +18,9 @@ docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sp
 edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/test.txt
-gitpython==3.1.11         # via -r requirements/test.txt
+gitpython==3.1.12         # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
-idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
+idna==2.10                # via -c requirements/constraints.txt, -r requirements/test.txt, idna-ssl, requests, yarl
 imagesize==1.2.0          # via sphinx
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest, stevedore
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
@@ -44,7 +44,7 @@ restructuredtext-lint==1.3.2  # via doc8
 six==1.15.0               # via bleach, doc8, edx-sphinx-theme, readme-renderer
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.4.1             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.4.2             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.4.0          # via -r requirements/pip-tools.in
-six==1.15.0               # via pip-tools
+pip-tools==5.5.0          # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -15,12 +15,12 @@ coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
 edx-lint==1.6             # via -r requirements/quality.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/test.txt
-gitpython==3.1.11         # via -r requirements/test.txt
+gitpython==3.1.12         # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
-idna==2.10                # via -r requirements/test.txt, idna-ssl, yarl
+idna==2.10                # via -c requirements/constraints.txt, -r requirements/test.txt, idna-ssl, yarl
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==5.6.4              # via -r requirements/quality.in, pylint
+isort==5.7.0              # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 multidict==5.1.0          # via -r requirements/test.txt, aiohttp, yarl
@@ -42,7 +42,7 @@ six==1.15.0               # via astroid, edx-lint
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via pydocstyle
 toml==0.10.2              # via -r requirements/test.txt, pylint, pytest
-typed-ast==1.4.1          # via astroid
+typed-ast==1.4.2          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/test.txt, aiohttp, yarl
 wrapt==1.12.1             # via astroid
 yarl==1.6.3               # via -r requirements/test.txt, aiohttp

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,9 +11,9 @@ chardet==3.0.4            # via -c requirements/constraints.txt, -r requirements
 coverage==5.3.1           # via pytest-cov
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/base.txt
-gitpython==3.1.11         # via -r requirements/base.txt
+gitpython==3.1.12         # via -r requirements/base.txt
 idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
-idna==2.10                # via -r requirements/base.txt, idna-ssl, yarl
+idna==2.10                # via -c requirements/constraints.txt, -r requirements/base.txt, idna-ssl, yarl
 importlib-metadata==2.1.1  # via -c requirements/constraints.txt, -r requirements/base.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/base.txt, pytest
 multidict==5.1.0          # via -r requirements/base.txt, aiohttp, yarl


### PR DESCRIPTION
[Python Requirements Upgrade](https://build.testeng.edx.org/job/pytest-repo-health-upgrade-python-requirements/32/display/redirect?page=changes) build failed because of the version conflict of `idna==3.1` which is pinned in `requests` as `idna<3` hence pinning the `idna` version until `requests` package removes the constraints. 