### PR TITLE
Pin diff-cover version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,7 +42,7 @@ multidict==5.1.0
     # via
     #   aiohttp
     #   yarl
-packaging==20.8
+packaging==20.9
     # via pytest
 pluggy==0.13.1
     # via pytest
@@ -52,13 +52,13 @@ pyparsing==2.4.7
     # via packaging
 pytest-aiohttp==0.3.0
     # via -r requirements/base.in
-pytest==6.2.1
+pytest==6.2.2
     # via
     #   -r requirements/base.in
     #   pytest-aiohttp
-pyyaml==5.4
+pyyaml==5.4.1
     # via -r requirements/base.in
-smmap==3.0.4
+smmap==3.0.5
     # via gitdb
 toml==0.10.2
     # via pytest

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -14,7 +14,7 @@ chardet==3.0.4
     #   requests
 codecov==2.1.11
     # via -r requirements/ci.in
-coverage==5.3.1
+coverage==5.4
     # via codecov
 distlib==0.3.1
     # via virtualenv
@@ -34,7 +34,7 @@ importlib-metadata==2.1.1
     #   virtualenv
 importlib-resources==5.1.0
     # via virtualenv
-packaging==20.8
+packaging==20.9
     # via tox
 pluggy==0.13.1
     # via tox
@@ -52,13 +52,13 @@ toml==0.10.2
     # via tox
 tox-battery==0.6.1
     # via -r requirements/ci.in
-tox==3.21.2
+tox==3.21.3
     # via
     #   -r requirements/ci.in
     #   tox-battery
-urllib3==1.26.2
+urllib3==1.26.3
     # via requests
-virtualenv==20.4.0
+virtualenv==20.4.2
     # via tox
 zipp==3.4.0
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,5 +16,8 @@ importlib-metadata<3.0
 # aiohttp latest version 3.7.3 requires chardet<4.0, can be removed once aiohttp==4.0.0 is released.
 chardet<4.0
 
+# diff-cover==4.2.0 requires chardet==4.0.0 which is pinned due to aiohttp issue
+diff-cover<4.2.0
+
 # requests has a constraint idna<3 in it, so pinning it unless requests updates the constraint
 idna<3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,6 +13,10 @@ appdirs==1.4.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
+asgiref==3.3.1
+    # via
+    #   -r requirements/quality.txt
+    #   django
 astroid==2.4.2
     # via
     #   -r requirements/quality.txt
@@ -47,23 +51,35 @@ click==7.1.2
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   click-log
+    #   code-annotations
     #   edx-lint
     #   pip-tools
+code-annotations==1.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-lint
 codecov==2.1.11
     # via -r requirements/ci.txt
-coverage==5.3.1
+coverage==5.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
 diff-cover==4.1.1
-    # via -r requirements/dev.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/dev.in
 distlib==0.3.1
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-edx-lint==1.6
+django==3.1.6
+    # via
+    #   -r requirements/quality.txt
+    #   code-annotations
+    #   edx-lint
+edx-lint==3.0.2
     # via -r requirements/quality.txt
 filelock==3.0.12
     # via
@@ -97,6 +113,7 @@ importlib-metadata==2.1.1
     #   -r requirements/quality.txt
     #   pluggy
     #   pytest
+    #   stevedore
     #   tox
     #   virtualenv
 importlib-resources==5.1.0
@@ -115,8 +132,10 @@ isort==5.7.0
     #   pylint
 jinja2-pluralize==0.3.0
     # via diff-cover
-jinja2==2.11.2
+jinja2==2.11.3
     # via
+    #   -r requirements/quality.txt
+    #   code-annotations
     #   diff-cover
     #   jinja2-pluralize
 lazy-object-proxy==1.4.3
@@ -124,7 +143,9 @@ lazy-object-proxy==1.4.3
     #   -r requirements/quality.txt
     #   astroid
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   -r requirements/quality.txt
+    #   jinja2
 mccabe==0.6.1
     # via
     #   -r requirements/quality.txt
@@ -134,12 +155,16 @@ multidict==5.1.0
     #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
-packaging==20.8
+packaging==20.9
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pytest
     #   tox
+pbr==5.5.1
+    # via
+    #   -r requirements/quality.txt
+    #   stevedore
 pip-tools==5.5.0
     # via -r requirements/pip-tools.txt
 pluggy==0.13.1
@@ -165,7 +190,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.3.0
+pylint-django==2.4.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -188,15 +213,25 @@ pyparsing==2.4.7
     #   packaging
 pytest-aiohttp==0.3.0
     # via -r requirements/quality.txt
-pytest-cov==2.11.0
+pytest-cov==2.11.1
     # via -r requirements/quality.txt
-pytest==6.2.1
+pytest==6.2.2
     # via
     #   -r requirements/quality.txt
     #   pytest-aiohttp
     #   pytest-cov
-pyyaml==5.4
-    # via -r requirements/quality.txt
+python-slugify==4.0.1
+    # via
+    #   -r requirements/quality.txt
+    #   code-annotations
+pytz==2021.1
+    # via
+    #   -r requirements/quality.txt
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/quality.txt
+    #   code-annotations
 requests==2.25.1
     # via
     #   -r requirements/ci.txt
@@ -209,14 +244,26 @@ six==1.15.0
     #   edx-lint
     #   tox
     #   virtualenv
-smmap==3.0.4
+smmap==3.0.5
     # via
     #   -r requirements/quality.txt
     #   gitdb
-snowballstemmer==2.0.0
+snowballstemmer==2.1.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
+sqlparse==0.4.1
+    # via
+    #   -r requirements/quality.txt
+    #   django
+stevedore==3.3.0
+    # via
+    #   -r requirements/quality.txt
+    #   code-annotations
+text-unidecode==1.3
+    # via
+    #   -r requirements/quality.txt
+    #   python-slugify
 toml==0.10.2
     # via
     #   -r requirements/ci.txt
@@ -226,7 +273,7 @@ toml==0.10.2
     #   tox
 tox-battery==0.6.1
     # via -r requirements/ci.txt
-tox==3.21.2
+tox==3.21.3
     # via
     #   -r requirements/ci.txt
     #   tox-battery
@@ -239,11 +286,11 @@ typing-extensions==3.7.4.3
     #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
-urllib3==1.26.2
+urllib3==1.26.3
     # via
     #   -r requirements/ci.txt
     #   requests
-virtualenv==20.4.0
+virtualenv==20.4.2
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,7 +22,7 @@ attrs==20.3.0
     #   pytest
 babel==2.9.0
     # via sphinx
-bleach==3.2.1
+bleach==3.3.0
     # via readme-renderer
 certifi==2020.12.5
     # via requests
@@ -33,7 +33,7 @@ chardet==3.0.4
     #   aiohttp
     #   doc8
     #   requests
-coverage==5.3.1
+coverage==5.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -79,7 +79,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-jinja2==2.11.2
+jinja2==2.11.3
     # via sphinx
 markupsafe==1.1.1
     # via jinja2
@@ -88,7 +88,7 @@ multidict==5.1.0
     #   -r requirements/test.txt
     #   aiohttp
     #   yarl
-packaging==20.8
+packaging==20.9
     # via
     #   -r requirements/test.txt
     #   bleach
@@ -115,16 +115,16 @@ pyparsing==2.4.7
     #   packaging
 pytest-aiohttp==0.3.0
     # via -r requirements/test.txt
-pytest-cov==2.11.0
+pytest-cov==2.11.1
     # via -r requirements/test.txt
-pytest==6.2.1
+pytest==6.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-aiohttp
     #   pytest-cov
-pytz==2020.5
+pytz==2021.1
     # via babel
-pyyaml==5.4
+pyyaml==5.4.1
     # via -r requirements/test.txt
 readme-renderer==28.0
     # via -r requirements/doc.in
@@ -138,11 +138,11 @@ six==1.15.0
     #   doc8
     #   edx-sphinx-theme
     #   readme-renderer
-smmap==3.0.4
+smmap==3.0.5
     # via
     #   -r requirements/test.txt
     #   gitdb
-snowballstemmer==2.0.0
+snowballstemmer==2.1.0
     # via sphinx
 sphinx==3.4.3
     # via
@@ -171,7 +171,7 @@ typing-extensions==3.7.4.3
     #   -r requirements/test.txt
     #   aiohttp
     #   yarl
-urllib3==1.26.2
+urllib3==1.26.3
     # via requests
 webencodings==0.5.1
     # via bleach

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.36.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.3
+pip==21.0.1
     # via -r requirements/pip.in
-setuptools==51.3.3
+setuptools==53.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,6 +9,8 @@ aiohttp==3.7.3
     #   -r requirements/test.txt
     #   github.py
     #   pytest-aiohttp
+asgiref==3.3.1
+    # via django
 astroid==2.4.2
     # via
     #   pylint
@@ -32,12 +34,19 @@ click-log==0.3.2
 click==7.1.2
     # via
     #   click-log
+    #   code-annotations
     #   edx-lint
-coverage==5.3.1
+code-annotations==1.1.0
+    # via edx-lint
+coverage==5.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-edx-lint==1.6
+django==3.1.6
+    # via
+    #   code-annotations
+    #   edx-lint
+edx-lint==3.0.2
     # via -r requirements/quality.in
 gitdb==4.0.5
     # via
@@ -63,6 +72,7 @@ importlib-metadata==2.1.1
     #   -r requirements/test.txt
     #   pluggy
     #   pytest
+    #   stevedore
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -71,8 +81,12 @@ isort==5.7.0
     # via
     #   -r requirements/quality.in
     #   pylint
+jinja2==2.11.3
+    # via code-annotations
 lazy-object-proxy==1.4.3
     # via astroid
+markupsafe==1.1.1
+    # via jinja2
 mccabe==0.6.1
     # via pylint
 multidict==5.1.0
@@ -80,10 +94,12 @@ multidict==5.1.0
     #   -r requirements/test.txt
     #   aiohttp
     #   yarl
-packaging==20.8
+packaging==20.9
     # via
     #   -r requirements/test.txt
     #   pytest
+pbr==5.5.1
+    # via stevedore
 pluggy==0.13.1
     # via
     #   -r requirements/test.txt
@@ -98,7 +114,7 @@ pydocstyle==5.1.1
     # via -r requirements/quality.in
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.3.0
+pylint-django==2.4.2
     # via edx-lint
 pylint-plugin-utils==0.6
     # via
@@ -116,25 +132,37 @@ pyparsing==2.4.7
     #   packaging
 pytest-aiohttp==0.3.0
     # via -r requirements/test.txt
-pytest-cov==2.11.0
+pytest-cov==2.11.1
     # via -r requirements/test.txt
-pytest==6.2.1
+pytest==6.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-aiohttp
     #   pytest-cov
-pyyaml==5.4
-    # via -r requirements/test.txt
+python-slugify==4.0.1
+    # via code-annotations
+pytz==2021.1
+    # via django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
 six==1.15.0
     # via
     #   astroid
     #   edx-lint
-smmap==3.0.4
+smmap==3.0.5
     # via
     #   -r requirements/test.txt
     #   gitdb
-snowballstemmer==2.0.0
+snowballstemmer==2.1.0
     # via pydocstyle
+sqlparse==0.4.1
+    # via django
+stevedore==3.3.0
+    # via code-annotations
+text-unidecode==1.3
+    # via python-slugify
 toml==0.10.2
     # via
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -23,7 +23,7 @@ chardet==3.0.4
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   aiohttp
-coverage==5.3.1
+coverage==5.4
     # via pytest-cov
 gitdb==4.0.5
     # via
@@ -58,7 +58,7 @@ multidict==5.1.0
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==20.8
+packaging==20.9
     # via
     #   -r requirements/base.txt
     #   pytest
@@ -76,16 +76,16 @@ pyparsing==2.4.7
     #   packaging
 pytest-aiohttp==0.3.0
     # via -r requirements/base.txt
-pytest-cov==2.11.0
+pytest-cov==2.11.1
     # via -r requirements/test.in
-pytest==6.2.1
+pytest==6.2.2
     # via
     #   -r requirements/base.txt
     #   pytest-aiohttp
     #   pytest-cov
-pyyaml==5.4
+pyyaml==5.4.1
     # via -r requirements/base.txt
-smmap==3.0.4
+smmap==3.0.5
     # via
     #   -r requirements/base.txt
     #   gitdb


### PR DESCRIPTION
**JIRA Issue:** [BOM-2301](https://openedx.atlassian.net/browse/BOM-2301)

### Description
- Pinned `diff-cover<4.2.0` to resolve `chardet` version conflicts in the [failing requirements upgrade process](https://build.testeng.edx.org/job/pytest-repo-health-upgrade-python-requirements/35/console). 
