### PR TITLE
fix: handling the case where output is str instead of tuple

### DIFF
--- a/pytest_repo_health/__init__.py
+++ b/pytest_repo_health/__init__.py
@@ -3,12 +3,12 @@ Plugin configures pytest to run repo health checks on a code repository.
 Plugin takes care of gathering checks, running checks,
 and outputting report based on data gathered during checks.
 """
-
+from typing import Union
 
 __version__ = "2.1.0"
 
 
-def health_metadata(parent_path, output_keys):
+def health_metadata(parent_path: list, output_keys: dict):
     """
     Make a decorator that attaches metadata to the target function.
 
@@ -39,7 +39,7 @@ def health_metadata(parent_path, output_keys):
     return health_metadata_decorator
 
 
-def add_key_to_metadata(output_key):
+def add_key_to_metadata(output_key: Union[str, tuple]):
     """
     Designed for checks which only define one key
 

--- a/pytest_repo_health/__init__.py
+++ b/pytest_repo_health/__init__.py
@@ -53,8 +53,9 @@ def add_key_to_metadata(output_key):
 
     def health_metadata_decorator(func):
         """Add metadata to function documenting the output keys it generates."""
+        final_output_key = tuple([output_key]) if isinstance(output_key, str) else output_key
         func.__dict__['pytest_repo_health'] = {
-            'output_keys': {output_key:func.__doc__.strip()}
+            'output_keys': {final_output_key:func.__doc__.strip()}
         }
         return func
     return health_metadata_decorator


### PR DESCRIPTION
For the use case where the decorator is used to add metadata for a key which only goes one level down
in results_dict.

This is for ease of use. This way, the decorator just needs to look like:
@add_key_to_metadata("key") rather than @add_key_to_metadata(("key"))
