### PR TITLE
fix: Conditional import of checks from repo-path

### DIFF
--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -10,7 +10,7 @@ import yaml
 
 from .fixtures.git import git_origin_url, git_repo  # pylint: disable=unused-import
 from .fixtures.github import github_client, github_repo  # pylint: disable=unused-import
-
+from .utils import get_git_origin_url
 
 session_data_holder_dict = defaultdict(dict)
 session_data_holder_dict["TIMESTAMP"] = datetime.datetime.now().date()
@@ -36,10 +36,17 @@ def pytest_configure(config):
         repo_path = config.getoption("repo_path")  # pylint: disable=redefined-outer-name
         if repo_path is None:
             repo_path = os.getcwd()
-        config.args.append(os.path.abspath(repo_path))
 
         # in case repo_health checks are in separate repo
         repo_health_path = config.getoption("repo_health_path")
+
+        # When repo-health script is ran on edx-repo-health on jenkins,
+        # it gives error for import mismatch as it collects same check from both directories
+        # Hence if origin is same for repo_path and repo_health_path then don't
+        # import checks from repo_path
+        if get_git_origin_url(repo_path) != get_git_origin_url(repo_health_path):
+            config.args.append(os.path.abspath(repo_path))
+
         if repo_health_path is not None:
             config.args.append(os.path.abspath(repo_health_path))
 

--- a/pytest_repo_health/utils.py
+++ b/pytest_repo_health/utils.py
@@ -1,0 +1,27 @@
+"""
+Utilities for pytest plugin
+"""
+from pathlib import Path
+
+from git import Repo
+
+
+def get_git_origin_url(repo_path):
+    """
+    Returns the origin url for the repo_path provided, returns None if doesn't has a remote origin.
+    """
+    if repo_path is None:
+        return None
+    path = Path(repo_path) / '.git'
+    # If there isn't a .git directory, this isn't a git repository
+    if not path.is_dir():
+        return None
+    git_repo = Repo(repo_path)
+    if git_repo is None:
+        return None
+    try:
+        origin = git_repo.remotes.origin
+    except AttributeError:
+        # This local repository isn't linked to an online origin
+        return None
+    return origin.url

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,39 @@
+"""
+Tests to make sure the utils for pytest-repo-health plugins work correctly.
+"""
+
+import git
+
+from pytest_repo_health.utils import get_git_origin_url
+
+
+def test_get_git_origin_url_on_non_git_dir(tmpdir):
+    """
+    Verify that the non git directory returns None on getting origin URL through get_git_origin_url
+    """
+    repo_dir = tmpdir / "target-repo"
+    response = get_git_origin_url(repo_dir)
+    assert response is None
+
+
+def test_get_git_origin_url_without_origin_set(tmpdir):
+    """
+    Verify that the git repository without remote "origin" set returns None
+    on getting origin URL through get_git_origin_url
+    """
+    repo_dir = tmpdir / "target-repo"
+    repo = git.Repo.init(repo_dir)
+    response = get_git_origin_url(repo_dir)
+    assert response is None
+
+
+def test_get_git_origin_url_with_origin_set(tmpdir):
+    """
+    Verify that the origin URL is retrieved through get_git_origin_url on valid git repository with origin set
+    """
+    url = "https://github.com/edx/pytest-repo-health.git"
+    repo_dir = tmpdir / "target-repo"
+    repo = git.Repo.init(repo_dir)
+    repo.create_remote("origin", url=url)
+    response = get_git_origin_url(repo_dir)
+    assert response == url


### PR DESCRIPTION
When repo-health script is ran on edx-repo-health on jenkins, it gives error for import mismatch as it collects same check from both directories.
Hence if origin is same for repo_path and repo_health_path then don't import checks from repo_path

BOM-2098