### PR TITLE
fix: Allow matching remote URL for .github repo (fix regex)

### DIFF
--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -10,7 +10,7 @@ import yaml
 
 from .fixtures.git import git_origin_url, git_repo  # pylint: disable=unused-import
 from .fixtures.github import github_client, github_repo  # pylint: disable=unused-import
-from .utils import get_git_origin
+from .utils import get_repo_remote_name
 
 session_data_holder_dict = defaultdict(dict)
 session_data_holder_dict["TIMESTAMP"] = datetime.datetime.now().date()
@@ -44,7 +44,7 @@ def pytest_configure(config):
         # it gives error for import mismatch as it collects same check from both directories
         # Hence if origin is same for repo_path and repo_health_path then don't
         # import checks from repo_path
-        if get_git_origin(repo_path) != get_git_origin(repo_health_path):
+        if get_repo_remote_name(repo_path) != get_repo_remote_name(repo_health_path):
             config.args.append(os.path.abspath(repo_path))
 
         if repo_health_path is not None:

--- a/pytest_repo_health/utils.py
+++ b/pytest_repo_health/utils.py
@@ -9,9 +9,11 @@ from git import Repo
 URL_PATTERN = r"(git@|https://)([\w\.@]+)(/|:)(?P<owner>[\w,\-,\_]+)/(?P<repo_name>[\w,\-,\_]+)(.git){0,1}((/){0,1})"
 
 
-def get_git_origin(repo_path):
+def get_repo_remote_name(repo_path):
     """
-    Returns the origin url for the repo_path provided, returns None if doesn't has a remote origin.
+    Returns the repo name from the remote url for the repo_path provided.
+    Returns None if repo doesn't have a remote named 'origin'.
+    Assumes repo is hosted on Github.
     """
     if repo_path is None:
         return None

--- a/pytest_repo_health/utils.py
+++ b/pytest_repo_health/utils.py
@@ -6,7 +6,16 @@ from pathlib import Path
 
 from git import Repo
 
-URL_PATTERN = r"(git@|https://)([\w\.@]+)(/|:)(?P<owner>[\w,\-,\_]+)/(?P<repo_name>[\w,\-,\_]+)(.git){0,1}((/){0,1})"
+# Assumes the last slash-separated component of the remote URL is the
+# name of the repo, providing for a possible extra `.git` or an extra
+# forward slash at the end. This works for Github's path structure
+# (which is what we need) but should also work for various other
+# remotes.
+#
+# Examples:
+# - https://github.com/edx/edx-platform.git
+# - git@github.com:edx/edx-platform.git
+URL_PATTERN = r"^(git@|https://).*/(?P<repo_name>[a-zA-Z0-9_\-.]+?)(\.git)?/?$"
 
 
 def get_repo_remote_name(repo_path):
@@ -29,5 +38,5 @@ def get_repo_remote_name(repo_path):
     except AttributeError:
         # This local repository isn't linked to an online origin
         return None
-    match = re.search(URL_PATTERN, origin.url)
+    match = re.fullmatch(URL_PATTERN, origin.url)
     return match.group("repo_name")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,3 +73,15 @@ def test_get_repo_remote_name_with_ssh_origin_without_git(tmpdir):
     repo.create_remote("origin", url=url)
     response = get_repo_remote_name(repo_dir)
     assert response == 'pytest-repo-health'
+
+
+def test_get_repo_remote_name_with_dot_in_name(tmpdir):
+    """
+    Regression test for edx/.github repo.
+    """
+    url = "https://github.com/edx/.github.git"
+    repo_dir = tmpdir / "target-repo"
+    repo = git.Repo.init(repo_dir)
+    repo.create_remote("origin", url=url)
+    response = get_repo_remote_name(repo_dir)
+    assert response == '.github'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,72 +4,72 @@ Tests to make sure the utils for pytest-repo-health plugins work correctly.
 
 import git
 
-from pytest_repo_health.utils import get_git_origin
+from pytest_repo_health.utils import get_repo_remote_name
 
 
-def test_get_git_origin_on_non_git_dir(tmpdir):
+def test_get_repo_remote_name_on_non_git_dir(tmpdir):
     """
-    Verify that the non git directory returns None on getting origin URL through get_git_origin
+    Verify that the non git directory returns None on getting origin URL through get_repo_remote_name
     """
     repo_dir = tmpdir / "target-repo"
-    response = get_git_origin(repo_dir)
+    response = get_repo_remote_name(repo_dir)
     assert response is None
 
 
-def test_get_git_origin_without_origin_set(tmpdir):
+def test_get_repo_remote_name_without_origin_set(tmpdir):
     """
     Verify that the git repository without remote "origin" set returns None
-    on getting origin URL through get_git_origin
+    on getting origin URL through get_repo_remote_name
     """
     repo_dir = tmpdir / "target-repo"
     repo = git.Repo.init(repo_dir)
-    response = get_git_origin(repo_dir)
+    response = get_repo_remote_name(repo_dir)
     assert response is None
 
 
-def test_get_git_origin_with_http_origin(tmpdir):
+def test_get_repo_remote_name_with_http_origin(tmpdir):
     """
-    Verify that the origin URL is retrieved through get_git_origin on valid git repository with origin set
+    Verify that the origin URL is retrieved through get_repo_remote_name on valid git repository with origin set
     """
     url = "https://github.com/edx/pytest-repo-health.git"
     repo_dir = tmpdir / "target-repo"
     repo = git.Repo.init(repo_dir)
     repo.create_remote("origin", url=url)
-    response = get_git_origin(repo_dir)
+    response = get_repo_remote_name(repo_dir)
     assert response == 'pytest-repo-health'
 
 
-def test_get_git_origin_with_http_origin_without_git(tmpdir):
+def test_get_repo_remote_name_with_http_origin_without_git(tmpdir):
     """
-    Verify that the origin URL is retrieved through get_git_origin on valid git repository with origin set
+    Verify that the origin URL is retrieved through get_repo_remote_name on valid git repository with origin set
     """
     url = "https://github.com/edx/pytest-repo-health"
     repo_dir = tmpdir / "target-repo"
     repo = git.Repo.init(repo_dir)
     repo.create_remote("origin", url=url)
-    response = get_git_origin(repo_dir)
+    response = get_repo_remote_name(repo_dir)
     assert response == 'pytest-repo-health'
 
 
-def test_get_git_origin_with_ssh_origin(tmpdir):
+def test_get_repo_remote_name_with_ssh_origin(tmpdir):
     """
-    Verify that the origin URL is retrieved through get_git_origin on valid git repository with origin set
+    Verify that the origin URL is retrieved through get_repo_remote_name on valid git repository with origin set
     """
     url = "git@github.com:edx/pytest-repo-health.git"
     repo_dir = tmpdir / "target-repo"
     repo = git.Repo.init(repo_dir)
     repo.create_remote("origin", url=url)
-    response = get_git_origin(repo_dir)
+    response = get_repo_remote_name(repo_dir)
     assert response == 'pytest-repo-health'
 
 
-def test_get_git_origin_with_ssh_origin_without_git(tmpdir):
+def test_get_repo_remote_name_with_ssh_origin_without_git(tmpdir):
     """
-    Verify that the origin URL is retrieved through get_git_origin on valid git repository with origin set
+    Verify that the origin URL is retrieved through get_repo_remote_name on valid git repository with origin set
     """
     url = "git@github.com:edx/pytest-repo-health"
     repo_dir = tmpdir / "target-repo"
     repo = git.Repo.init(repo_dir)
     repo.create_remote("origin", url=url)
-    response = get_git_origin(repo_dir)
+    response = get_repo_remote_name(repo_dir)
     assert response == 'pytest-repo-health'


### PR DESCRIPTION
The regex was disallowing repos with dots in their name. This commit adds
`.` as an allowable character, but includes some other changes as well:

- Remove commas from regex (not valid syntax)
- Replace `{0,1}` with `?` and remove some unneeded groupings
- Remove owner capture, since it wasn't being used
- Allow hostname and path prefix to just be matched by an undifferentiated
  `.*` since we don't really care about the structure there.
- Both anchor the regex and switch to fullmatch, which is redundant but
  both are best-practice unless the situation calls for something more
  relaxed.
- Rename regex var to better represent its purpose.

Arguably we don't really need the git/https scheme matching, but there's a
small risk that this could be pointed at a repo cloned from a directory,
and that directory might have a generic name like "workspace" or
"checkout". Until we have a need to relax this constraint, we should
probably keep it in place.

There is an additional refactoring commit that renames this utility function
to better represent its purpose and improves on the docstring.